### PR TITLE
Fix readline osx

### DIFF
--- a/addok/shell.py
+++ b/addok/shell.py
@@ -3,7 +3,12 @@ import cmd
 import json
 import logging
 import re
-import readline
+
+try:
+    import gnureadline as readline
+except ImportError:
+    import readline
+
 import time
 from pathlib import Path
 

--- a/addok/shell.py
+++ b/addok/shell.py
@@ -5,9 +5,9 @@ import logging
 import re
 
 try:
-    import gnureadline as readline
+    import gnureadline as readline # for OSX
 except ImportError:
-    import readline
+    import readline # normal way
 
 import time
 from pathlib import Path

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -9,6 +9,12 @@ You need sudo grants on this server, and it must be connected to Internet.
 
     sudo apt install redis-server python3.5 python3.5-dev python-virtualenv wget nginx uwsgi uwsgi-plugin-python3 bzip2
 
+  For Mac OS X users only:
+
+    pip install gnureadline
+
+  Some platforms, such as Mac OS X, do not ship with GNU readline installed. The readline extension module in the standard library of Mac “system” Python uses NetBSD’s editline (libedit) library instead, which is a readline replacement with a less restrictive software license.
+
 ## Create a Unix user
 
 Here we use the name `addok`, but this name is up to you. Remember to change it


### PR DESCRIPTION
Fix
-------
Corrige la PermissionError renvoyé par readline.read_history_file survenant lors de la lecture du .cli_history pour les utilisateurs de Mac OSX. 