### PR TITLE
Experiment using coroutines

### DIFF
--- a/addok/bin/__init__.py
+++ b/addok/bin/__init__.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
+import asyncio
 import os
 
+import asyncio_redis
 
 def main():
 
@@ -19,12 +21,19 @@ def main():
 
     from addok import config, hooks
     config.load(config)
+    asyncio.get_event_loop().run_until_complete(setup_pooler(config))
     hooks.register_command(subparsers)
     args = main_parser.parse_args()
     if getattr(args, 'func', None):
         args.func(args)
     else:
         main_parser.print_help()
+
+
+async def setup_pooler(config):
+    config.connection = await asyncio_redis.Pool.create(
+        poolsize=10, **config.REDIS)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR is just an experiment. It's not finished (the redis connections should
be properly closed, for starters).

This will not land because the overhead of creating up to 100 coroutines (if
there's 100 IDs on a redis query) is far too high to gain anything on the 15ms
or so that is needed to get the results from a local redis instance.

If at some point in the future the redis instance should be on a remote server,
then the overhead of the round trip between the servers may be higher, and
justify using coroutines to get the results asynchronously (in a non-blocking
way).