### PR TITLE
Add config.on_load decorator

### DIFF
--- a/addok/db.py
+++ b/addok/db.py
@@ -1,5 +1,7 @@
 import redis
 
+from addok.config import config
+
 
 class DBRedis:
     instance = None
@@ -11,3 +13,8 @@ class DBRedis:
         return getattr(self.instance, name)
 
 DB = DBRedis()
+
+
+@config.on_load
+def connect():
+    DB.connect(**config.REDIS)

--- a/addok/helpers/text.py
+++ b/addok/helpers/text.py
@@ -72,6 +72,7 @@ normalize = yielder(_normalize)
 SYNONYMS = {}
 
 
+@config.on_load
 def load_synonyms():
     path = config.SYNONYMS_PATH
     if not path:
@@ -88,7 +89,6 @@ def load_synonyms():
                 if not synonym:
                     continue
                 SYNONYMS[synonym] = wanted
-load_synonyms()
 
 
 def _synonymize(t):

--- a/addok/pytest.py
+++ b/addok/pytest.py
@@ -3,13 +3,13 @@ import uuid
 
 import pytest
 
-from addok.db import DB
-
 
 def pytest_configure():
+    # Do not import files from the top of the module, otherwise they will
+    # not taken into account by the coverage.
+    from addok.config import config
     # Be sure not to load local config during tests.
     os.environ['ADDOK_CONFIG_MODULE'] = ''
-    from addok.config import config
     import logging
     logging.basicConfig(level=logging.DEBUG)
     config.REDIS['db'] = 15
@@ -17,12 +17,12 @@ def pytest_configure():
 
 
 def pytest_runtest_setup(item):
-    from addok.config import config
+    from addok.db import DB
     assert DB.connection_pool.connection_kwargs['db'] == 15
 
 
 def pytest_runtest_teardown(item, nextitem):
-    from addok.config import config
+    from addok.db import DB
     assert DB.connection_pool.connection_kwargs['db'] == 15
     DB.flushdb()
 
@@ -115,6 +115,5 @@ class MonkeyPatchWrapper(object):
 
 @pytest.fixture()
 def config(request, monkeypatch):
-
     from addok.config import config as addok_config
     return MonkeyPatchWrapper(monkeypatch, addok_config)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,6 +1,17 @@
-from addok.config import config
 from addok.db import DB
 
 
 def test_connection_port_is_not_default_one():
     assert DB.connection_pool.connection_kwargs['db'] == 15
+
+
+def test_config_on_load_is_called_on_config_load():
+    from addok.config import Config
+    config = Config()
+
+    @config.on_load
+    def on_load():
+        on_load.called = True
+
+    config.load()
+    assert on_load.called


### PR DESCRIPTION
This will run the decorated function when the config is loaded.

I needed it to fix synonyms file loaded too early. And also took the opportunity to use for the db: was not fan of the config loading the db.

cc @vinyll 
