### PR TITLE
Serialize docs in python and store them as blob

### DIFF
--- a/addok/config/__init__.py
+++ b/addok/config/__init__.py
@@ -14,13 +14,14 @@ class Config(dict):
     def __init__(self):
         self._post_load_func = []
         self.loaded = False
-        self.path_keys = [
+        self.paths_lists = [
             'QUERY_PROCESSORS', 'RESULTS_COLLECTORS',
             'SEARCH_RESULT_PROCESSORS', 'REVERSE_RESULT_PROCESSORS',
             'PROCESSORS', 'INDEXERS', 'DEINDEXERS', 'BATCH_PROCESSORS',
             'SEARCH_PREPROCESSORS', 'RESULTS_FORMATTERS',
             'HOUSENUMBER_PROCESSORS',
         ]
+        self.paths = ['DOCUMENT_SERIALIZER']
         self.plugins = [
             'addok.shell',
             'addok.http.base',
@@ -104,8 +105,14 @@ class Config(dict):
             func()
 
     def resolve(self):
-        for key in self.path_keys:
+        for key in self.paths_lists:
             self.resolve_paths(key)
+        for key in self.paths:
+            self.resolve_path(key)
+
+    def resolve_path(self, key):
+        from addok.helpers import import_by_path
+        self[key] = import_by_path(self[key])
 
     def resolve_paths(self, key):
         from addok.helpers import import_by_path

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -81,6 +81,8 @@ DEINDEXERS = [
     'addok.helpers.index.housenumbers_deindexer',
     'addok.helpers.index.document_deindexer',
 ]
+# Any object like instance having `loads` and `dumps` methods.
+DOCUMENT_SERIALIZER = 'addok.helpers.serializers.ZlibSerializer'
 
 # Fields to be indexed
 # If you want a housenumbers field but need to name it differently, just add

--- a/addok/helpers/__init__.py
+++ b/addok/helpers/__init__.py
@@ -23,10 +23,11 @@ def import_by_path(path):
     """
     if not isinstance(path, str):
         return path
-    module_path, name = path.rsplit('.', 1)
-    module = import_module(module_path)
-    attr = getattr(module, name)
-    return attr
+    module_path, *name = path.rsplit('.', 1)
+    func = import_module(module_path)
+    if name:
+        func = getattr(func, name[0])
+    return func
 
 
 def yielder(func):

--- a/addok/helpers/keys.py
+++ b/addok/helpers/keys.py
@@ -6,10 +6,6 @@ def document_key(s):
     return 'd|{}'.format(s)
 
 
-def housenumber_field_key(s):
-    return 'h|{}'.format(s)
-
-
 def geohash_key(s):
     return 'g|{}'.format(s)
 

--- a/addok/helpers/serializers.py
+++ b/addok/helpers/serializers.py
@@ -1,0 +1,13 @@
+import json
+import zlib
+
+
+class ZlibSerializer:
+
+    @classmethod
+    def dumps(cls, data):
+        return zlib.compress(json.dumps(data).encode())
+
+    @classmethod
+    def loads(cls, data):
+        return json.loads(zlib.decompress(data).decode())

--- a/addok/pairs.py
+++ b/addok/pairs.py
@@ -49,12 +49,8 @@ def housenumbers_pairs_indexer(pipe, key, doc, tokens, **kwargs):
 
 
 def housenumbers_pairs_deindexer(db, key, doc, tokens, **kwargs):
-    for field, value in doc.items():
-        field = field.decode()
-        if not field.startswith('h|'):
-            continue
-        number, lat, lon, *extra = value.decode().split('|')
-        hn = field[2:]
+    housenumbers = doc.get('housenumbers', {})
+    for hn, data in housenumbers.items():
         for token in tokens:
             k = '|'.join(['didx', hn, token])
             commons = db.zinterstore(k, [keys.token_key(hn),

--- a/addok/pytest.py
+++ b/addok/pytest.py
@@ -55,7 +55,7 @@ class DummyDoc(dict):
 
     def index(self):
         from addok.helpers.index import index_document
-        index_document(self)
+        index_document(self.copy())
 
 
 @pytest.fixture

--- a/docs/config.md
+++ b/docs/config.md
@@ -167,6 +167,17 @@ Default score for the relation token to document.
 
     DEFAULT_BOOST = 1.0
 
+#### DOCUMENT_SERIALIZER (path)
+Path to the serializer to be used for storing documents. Must have `loads` and
+`dumps` methods.
+
+    DOCUMENT_SERIALIZER = 'addok.helpers.serializers.ZlibSerializer'
+
+For a faster option (but using more RAM), use `marshal` instead.
+
+    DOCUMENT_SERIALIZER = 'marshal'
+
+
 #### GEOHASH_PRECISION (int)
 Size of the geohash. The bigger the setting, the smaller the hash.
 See [Geohash on Wikipedia](http://en.wikipedia.org/wiki/Geohash).

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -5,7 +5,7 @@ from addok.core import search
 def test_process_should_index_by_default(factory):
     doc = factory(skip_index=True, name="Melicocq")
     assert not search("Mélicocq")
-    process(doc)
+    process(doc.copy())
     assert search("Melicocq")
 
 
@@ -21,6 +21,6 @@ def test_process_should_update_if_action_is_given(factory):
     assert search("rue")
     doc["_action"] = "update"
     doc["name"] = "avenue de l'avoine"
-    process(doc)
+    process(doc.copy())
     assert search("avenue")
     assert not search("rue")


### PR DESCRIPTION
Switch from Redis Hash to python serialized string:
- prepare for external storage source
- allow for fastest document CRUD (when using pure "marshal", which also consumes a bit more RAM than the Hash as it is now)
- make the document storage a bit simpler, by allowing list and dicts as values (no need for joining the values in one string when some field has multiple values, and not need to pack/unpack the housenumbers extra fields), and without the need for decoding keys and values (as redis only returns bytes).

Made some stats about serializations with one address document:

### Dumps
```
  serializer	time		time-diff	size	size-diff
        json:	0.599154	 100.00%	2335	 100.00%
  simplejson:	0.808757	 134.98%	2335	 100.00%
       ujson:	0.167954	  28.03%	2126	  91.05%
     msgpack:	0.257895	  43.04%	1776	  76.06%
        cbor:	0.155541	  25.96%	1801	  77.13%
    jsonzlib:	1.084697	 181.04%	586	  25.10%
     jsonbz2:	3.807833	 635.54%	577	  24.71%
    jsongzip:	3.799891	 634.21%	577	  24.71%
     marshal:	0.086772	  14.48%	1984	  84.97%
 marshalzlib:	0.595275	  99.35%	865	  37.04%
 marshallzma:	19.980485	3334.79%	836	  35.80%
  marshalbz2:	4.481185	 747.92%	966	  41.37%
 marshalgzip:	0.928504	 154.97%	860	  36.83%
      pickle:	0.131090	  21.88%	2188	  93.70%
     pickle2:	0.134778	  22.49%	2188	  93.70%
     _pickle:	0.127216	  21.23%	2188	  93.70%
    _pickle2:	0.147294	  24.58%	2188	  93.70%
        bson:	3.973199	 663.14%	2086	  89.34%
```

### Loads
```
  serializer	time		time-diff
        json:	0.362314	 100.00%
  simplejson:	0.364273	 100.54%
       ujson:	0.248480	  68.58%
     msgpack:	0.139441	  38.49%
        cbor:	0.237211	  65.47%
    jsonzlib:	0.438117	 120.92%
     jsonbz2:	0.876458	 241.91%
    jsongzip:	0.885568	 244.42%
     marshal:	0.146422	  40.41%
 marshalzlib:	0.239236	  66.03%
 marshallzma:	0.534252	 147.46%
  marshalbz2:	0.835766	 230.67%
 marshalgzip:	0.537275	 148.29%
      pickle:	0.209560	  57.84%
     pickle2:	0.197942	  54.63%
     _pickle:	0.202589	  55.92%
    _pickle2:	0.198803	  54.87%
        bson:	4.278878	1180.98%
```

Some stats with the departments 59 and 62 loaded:

*import time:* cumulated time of import
*search time:* average process time on 1000 times "rue des lilas" search
*db size:* database size as given by redis INFO command
*documents index size:* cumulated size of all documents keys / cumulated size of all keys

| branch | import time | search time | db size | documents index size |
| ---------- | ---------------- | ------ | ---- | ---- |
| master (Hash) | 96s | 31.5ms | 612Mo | 48.3M / 140.7M |
| marshal | 90s | 29.7ms | 691M | 68.3M / 160.7M |
| json + zlib | 95s | 34ms | 589M | 42.5M / 134.7M |
| msgpack | 106s | 33.4ms | 690M | 65.7M / 158.1M |
