### PR TITLE
Add Lua scripts to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include requirements.txt
 recursive-include addok/resources *
+recursive-include addok/helpers/lua *


### PR DESCRIPTION
When installing via `pip`, the lua scripts were missing. This means that anything using the `scripts.*` (e.g. `scripts.zinter`) would fail.

This commit adds the Lua files to the MANIFEST.