### PR TITLE
Do not fail in shell if house "number" is not a digit

### DIFF
--- a/addok/shell.py
+++ b/addok/shell.py
@@ -339,7 +339,10 @@ class Cmd(cmd.Cmd):
         if housenumbers:
             def sorter(item):
                 k, v = item
-                return int(re.match(r'\d+', v.split('|')[0]).group())
+                try:
+                    return int(re.match(r'^\d+', v).group())
+                except AttributeError:
+                    return -1
             housenumbers = sorted(housenumbers.items(), key=sorter)
             housenumbers = ['{}: {}'.format(k[2:], v) for k, v in housenumbers]
             print(white('housenumbers'), magenta(', '.join(housenumbers)))


### PR DESCRIPTION
As per #206, but with a couple of differences: 

* We need to return a number from the `sorter`, so I've decided on `-1` for houses that don't have a number at the start.
* I've changed the regex to only match numbers at the start of the string, this is because some house names have numbers in them, for example `The 9 Elms`. This should not be sorted in to the 9th position.