### PR TITLE
Allow multiple values for filters

### DIFF
--- a/addok/helpers/index.py
+++ b/addok/helpers/index.py
@@ -190,11 +190,14 @@ def housenumbers_deindexer(db, key, doc, tokens, **kwargs):
 
 def filters_indexer(pipe, key, doc, tokens, **kwargs):
     for name in config.FILTERS:
-        value = doc.get(name)
-        if value:
-            # We need a SortedSet because it will be used in intersect with
-            # tokens SortedSets.
-            pipe.sadd(keys.filter_key(name, value), key)
+        values = doc.get(name)
+        if values:
+            if not isinstance(values, (list, tuple)):
+                values = [values]
+            for value in values:
+                # We need a SortedSet because it will be used in intersect with
+                # tokens SortedSets.
+                pipe.sadd(keys.filter_key(name, value), key)
     # Special case for housenumber type, because it's not a real type
     if "type" in config.FILTERS and config.HOUSENUMBERS_FIELD \
        and doc.get(config.HOUSENUMBERS_FIELD):
@@ -203,10 +206,11 @@ def filters_indexer(pipe, key, doc, tokens, **kwargs):
 
 def filters_deindexer(db, key, doc, tokens, **kwargs):
     for name in config.FILTERS:
-        # Doc is raw from DB, so it has byte keys.
-        value = doc.get(name)
-        if value:
-            # Doc is raw from DB, so it has byte values.
-            db.srem(keys.filter_key(name, value), key)
+        values = doc.get(name)
+        if values:
+            if not isinstance(values, (list, tuple)):
+                values = [values]
+            for value in values:
+                db.srem(keys.filter_key(name, value), key)
     if "type" in config.FILTERS:
         db.srem(keys.filter_key("type", "housenumber"), key)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -263,6 +263,16 @@ def test_housenumber_type_can_be_filtered(factory):
     assert street_without_housenumber['id'] not in ids
 
 
+def test_filter_indexes_multiple_values(factory):
+    city = factory(name="Paris", type=["city", "municipality"])
+    results = search("paris", type="city")
+    ids = [r.id for r in results]
+    assert city['id'] in ids
+    results = search("paris", type="municipality")
+    ids = [r.id for r in results]
+    assert city['id'] in ids
+
+
 def test_housenumber_are_not_computed_if_another_type_is_asked(factory):
     factory(name="rue de Bamako", type="street",
             housenumbers={'11': {'lat': '48.3254', 'lon': '2.256'}})


### PR DESCRIPTION
Goal is to index multiple values as filters when the value is a list (we already index multiple values for normal indexes).