### PR TITLE
Use explicit PATH(S) suffixes for settings, fix #224

### DIFF
--- a/addok/autocomplete.py
+++ b/addok/autocomplete.py
@@ -125,16 +125,16 @@ def register_command(subparsers):
 
 
 def configure(config):
-    config.RESULTS_COLLECTORS_PATHS.insert(0, only_commons_but_geohash_try_autocomplete_collector)  # noqa
+    config.RESULTS_COLLECTORS_PYPATHS.insert(0, only_commons_but_geohash_try_autocomplete_collector)  # noqa
     target = 'addok.helpers.collectors.only_commons'
-    if target in config.RESULTS_COLLECTORS_PATHS:
-        idx = config.RESULTS_COLLECTORS_PATHS.index(target)
-        config.RESULTS_COLLECTORS_PATHS.insert(idx + 1, only_commons_try_autocomplete_collector)  # noqa
-        config.RESULTS_COLLECTORS_PATHS.insert(idx + 1, no_meaningful_but_common_try_autocomplete_collector)  # noqa
+    if target in config.RESULTS_COLLECTORS_PYPATHS:
+        idx = config.RESULTS_COLLECTORS_PYPATHS.index(target)
+        config.RESULTS_COLLECTORS_PYPATHS.insert(idx + 1, only_commons_try_autocomplete_collector)  # noqa
+        config.RESULTS_COLLECTORS_PYPATHS.insert(idx + 1, no_meaningful_but_common_try_autocomplete_collector)  # noqa
     target = 'addok.helpers.collectors.extend_results_reducing_tokens'
-    if target in config.RESULTS_COLLECTORS_PATHS:
-        idx = config.RESULTS_COLLECTORS_PATHS.index(target)
-        config.RESULTS_COLLECTORS_PATHS.insert(idx, autocomplete_meaningful_collector)  # noqa
+    if target in config.RESULTS_COLLECTORS_PYPATHS:
+        idx = config.RESULTS_COLLECTORS_PYPATHS.index(target)
+        config.RESULTS_COLLECTORS_PYPATHS.insert(idx, autocomplete_meaningful_collector)  # noqa
 
 
 def do_autocomplete(self, s):

--- a/addok/autocomplete.py
+++ b/addok/autocomplete.py
@@ -125,16 +125,16 @@ def register_command(subparsers):
 
 
 def configure(config):
-    config.RESULTS_COLLECTORS.insert(0, only_commons_but_geohash_try_autocomplete_collector)  # noqa
+    config.RESULTS_COLLECTORS_PATHS.insert(0, only_commons_but_geohash_try_autocomplete_collector)  # noqa
     target = 'addok.helpers.collectors.only_commons'
-    if target in config.RESULTS_COLLECTORS:
-        idx = config.RESULTS_COLLECTORS.index(target)
-        config.RESULTS_COLLECTORS.insert(idx + 1, only_commons_try_autocomplete_collector)  # noqa
-        config.RESULTS_COLLECTORS.insert(idx + 1, no_meaningful_but_common_try_autocomplete_collector)  # noqa
+    if target in config.RESULTS_COLLECTORS_PATHS:
+        idx = config.RESULTS_COLLECTORS_PATHS.index(target)
+        config.RESULTS_COLLECTORS_PATHS.insert(idx + 1, only_commons_try_autocomplete_collector)  # noqa
+        config.RESULTS_COLLECTORS_PATHS.insert(idx + 1, no_meaningful_but_common_try_autocomplete_collector)  # noqa
     target = 'addok.helpers.collectors.extend_results_reducing_tokens'
-    if target in config.RESULTS_COLLECTORS:
-        idx = config.RESULTS_COLLECTORS.index(target)
-        config.RESULTS_COLLECTORS.insert(idx, autocomplete_meaningful_collector)  # noqa
+    if target in config.RESULTS_COLLECTORS_PATHS:
+        idx = config.RESULTS_COLLECTORS_PATHS.index(target)
+        config.RESULTS_COLLECTORS_PATHS.insert(idx, autocomplete_meaningful_collector)  # noqa
 
 
 def do_autocomplete(self, s):

--- a/addok/config/__init__.py
+++ b/addok/config/__init__.py
@@ -97,22 +97,20 @@ class Config(dict):
             func()
 
     def resolve(self):
-        # Two-pass process given that you cannot iterate over a dict
-        # and enrich it at the same time.
-        for path_key in [key for key in self if '_PATH' in key]:
-            if path_key.endswith('_PATHS'):
-                self.resolve_paths(path_key)
-            elif path_key.endswith('_PATH'):
-                self.resolve_path(path_key)
+        for key in list(self.keys()):
+            if key.endswith('_PYPATHS'):
+                self.resolve_paths(key)
+            elif key.endswith('_PYPATH'):
+                self.resolve_path(key)
 
     def resolve_path(self, key):
         from addok.helpers import import_by_path
-        self[key[:-len('_PATH')]] = import_by_path(self[key])
+        self[key[:-len('_PYPATH')]] = import_by_path(self[key])
 
     def resolve_paths(self, key):
         from addok.helpers import import_by_path
-        self[key[:-len('_PATHS')]] = [import_by_path(path)
-                                      for path in self[key]]
+        self[key[:-len('_PYPATHS')]] = [import_by_path(path)
+                                        for path in self[key]]
 
 
 config = Config()

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -33,36 +33,36 @@ MAX_EDGE_NGRAMS = 20
 SYNONYMS_PATH = None
 
 # Pipeline stream to be used.
-PROCESSORS_PATHS = [  # Rename in TOKEN_PROCESSORS / STRING_PROCESSORS?
+PROCESSORS_PYPATHS = [  # Rename in TOKEN_PROCESSORS / STRING_PROCESSORS?
     'addok.helpers.text.tokenize',
     'addok.helpers.text.normalize',
     'addok.helpers.text.synonymize',
 ]
-QUERY_PROCESSORS_PATHS = []
+QUERY_PROCESSORS_PYPATHS = []
 # Remove SEARCH_PREFIXES.
-SEARCH_PREPROCESSORS_PATHS = [
+SEARCH_PREPROCESSORS_PYPATHS = [
     'addok.helpers.search.tokenize',
     'addok.helpers.search.search_tokens',
     'addok.helpers.search.select_tokens',
     'addok.helpers.search.set_should_match_threshold',
 ]
-BATCH_PROCESSORS_PATHS = [
+BATCH_PROCESSORS_PYPATHS = [
     'addok.batch.to_json',
 ]
-DOCUMENT_PROCESSORS_PATHS = [
+DOCUMENT_PROCESSORS_PYPATHS = [
     'addok.helpers.index.prepare_housenumbers',
     'addok.ds.store_documents',
     'addok.helpers.index.index_documents',
 ]
 BATCH_CHUNK_SIZE = 1000
-RESULTS_COLLECTORS_PATHS = [
+RESULTS_COLLECTORS_PYPATHS = [
     'addok.helpers.collectors.only_commons',
     'addok.helpers.collectors.bucket_with_meaningful',
     'addok.helpers.collectors.reduce_with_other_commons',
     'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',  # noqa
     'addok.helpers.collectors.extend_results_reducing_tokens',
 ]
-SEARCH_RESULT_PROCESSORS_PATHS = [
+SEARCH_RESULT_PROCESSORS_PYPATHS = [
     'addok.helpers.results.match_housenumber',
     'addok.helpers.results.make_labels',
     'addok.helpers.results.score_by_importance',
@@ -70,15 +70,15 @@ SEARCH_RESULT_PROCESSORS_PATHS = [
     'addok.helpers.results.score_by_ngram_distance',
     'addok.helpers.results.score_by_geo_distance',
 ]
-REVERSE_RESULT_PROCESSORS_PATHS = [
+REVERSE_RESULT_PROCESSORS_PYPATHS = [
     'addok.helpers.results.load_closer',
     'addok.helpers.results.make_labels',
     'addok.helpers.results.score_by_geo_distance',
 ]
-RESULTS_FORMATTERS_PATHS = [
+RESULTS_FORMATTERS_PYPATHS = [
     'addok.helpers.formatters.geojson',
 ]
-INDEXERS_PATHS = [
+INDEXERS_PYPATHS = [
     'addok.helpers.index.HousenumbersIndexer',
     'addok.helpers.index.FieldsIndexer',
     # Both pairs indexers must be after `FieldsIndexer`.
@@ -90,9 +90,9 @@ INDEXERS_PATHS = [
     'addok.helpers.index.GeohashIndexer',
 ]
 # Any object like instance having `loads` and `dumps` methods.
-DOCUMENT_SERIALIZER_PATH = 'addok.helpers.serializers.ZlibSerializer'
+DOCUMENT_SERIALIZER_PYPATH = 'addok.helpers.serializers.ZlibSerializer'
 
-DOCUMENT_STORE_PATH = 'addok.ds.RedisStore'
+DOCUMENT_STORE_PYPATH = 'addok.ds.RedisStore'
 
 # Fields to be indexed
 # If you want a housenumbers field but need to name it differently, just add

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -33,36 +33,36 @@ MAX_EDGE_NGRAMS = 20
 SYNONYMS_PATH = None
 
 # Pipeline stream to be used.
-PROCESSORS = [  # Rename in TOKEN_PROCESSORS / STRING_PROCESSORS?
+PROCESSORS_PATHS = [  # Rename in TOKEN_PROCESSORS / STRING_PROCESSORS?
     'addok.helpers.text.tokenize',
     'addok.helpers.text.normalize',
     'addok.helpers.text.synonymize',
 ]
-QUERY_PROCESSORS = []
+QUERY_PROCESSORS_PATHS = []
 # Remove SEARCH_PREFIXES.
-SEARCH_PREPROCESSORS = [
+SEARCH_PREPROCESSORS_PATHS = [
     'addok.helpers.search.tokenize',
     'addok.helpers.search.search_tokens',
     'addok.helpers.search.select_tokens',
     'addok.helpers.search.set_should_match_threshold',
 ]
-BATCH_PROCESSORS = [
+BATCH_PROCESSORS_PATHS = [
     'addok.batch.to_json',
 ]
-DOCUMENT_PROCESSORS = [
+DOCUMENT_PROCESSORS_PATHS = [
     'addok.helpers.index.prepare_housenumbers',
     'addok.ds.store_documents',
     'addok.helpers.index.index_documents',
 ]
 BATCH_CHUNK_SIZE = 1000
-RESULTS_COLLECTORS = [
+RESULTS_COLLECTORS_PATHS = [
     'addok.helpers.collectors.only_commons',
     'addok.helpers.collectors.bucket_with_meaningful',
     'addok.helpers.collectors.reduce_with_other_commons',
     'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',  # noqa
     'addok.helpers.collectors.extend_results_reducing_tokens',
 ]
-SEARCH_RESULT_PROCESSORS = [
+SEARCH_RESULT_PROCESSORS_PATHS = [
     'addok.helpers.results.match_housenumber',
     'addok.helpers.results.make_labels',
     'addok.helpers.results.score_by_importance',
@@ -70,15 +70,15 @@ SEARCH_RESULT_PROCESSORS = [
     'addok.helpers.results.score_by_ngram_distance',
     'addok.helpers.results.score_by_geo_distance',
 ]
-REVERSE_RESULT_PROCESSORS = [
+REVERSE_RESULT_PROCESSORS_PATHS = [
     'addok.helpers.results.load_closer',
     'addok.helpers.results.make_labels',
     'addok.helpers.results.score_by_geo_distance',
 ]
-RESULTS_FORMATTERS = [
+RESULTS_FORMATTERS_PATHS = [
     'addok.helpers.formatters.geojson',
 ]
-INDEXERS = [
+INDEXERS_PATHS = [
     'addok.helpers.index.HousenumbersIndexer',
     'addok.helpers.index.FieldsIndexer',
     # Both pairs indexers must be after `FieldsIndexer`.
@@ -90,9 +90,9 @@ INDEXERS = [
     'addok.helpers.index.GeohashIndexer',
 ]
 # Any object like instance having `loads` and `dumps` methods.
-DOCUMENT_SERIALIZER = 'addok.helpers.serializers.ZlibSerializer'
+DOCUMENT_SERIALIZER_PATH = 'addok.helpers.serializers.ZlibSerializer'
 
-DOCUMENT_STORE = 'addok.ds.RedisStore'
+DOCUMENT_STORE_PATH = 'addok.ds.RedisStore'
 
 # Fields to be indexed
 # If you want a housenumbers field but need to name it differently, just add

--- a/addok/fuzzy.py
+++ b/addok/fuzzy.py
@@ -99,9 +99,10 @@ def try_fuzzy(helper, tokens, include_common=True):
 
 def configure(config):
     target = 'addok.helpers.collectors.extend_results_reducing_tokens'
-    if target in config.RESULTS_COLLECTORS:
-        idx = config.RESULTS_COLLECTORS.index(target)
-        config.RESULTS_COLLECTORS.insert(idx, 'addok.fuzzy.fuzzy_collector')
+    if target in config.RESULTS_COLLECTORS_PATHS:
+        idx = config.RESULTS_COLLECTORS_PATHS.index(target)
+        config.RESULTS_COLLECTORS_PATHS.insert(
+            idx, 'addok.fuzzy.fuzzy_collector')
 
 
 def do_fuzzy(self, word):

--- a/addok/fuzzy.py
+++ b/addok/fuzzy.py
@@ -1,6 +1,5 @@
 import string
 
-from addok.config import config
 from addok.db import DB
 from addok.helpers import keys as dbkeys
 from addok.helpers import blue, white
@@ -99,9 +98,9 @@ def try_fuzzy(helper, tokens, include_common=True):
 
 def configure(config):
     target = 'addok.helpers.collectors.extend_results_reducing_tokens'
-    if target in config.RESULTS_COLLECTORS_PATHS:
-        idx = config.RESULTS_COLLECTORS_PATHS.index(target)
-        config.RESULTS_COLLECTORS_PATHS.insert(
+    if target in config.RESULTS_COLLECTORS_PYPATHS:
+        idx = config.RESULTS_COLLECTORS_PYPATHS.index(target)
+        config.RESULTS_COLLECTORS_PYPATHS.insert(
             idx, 'addok.fuzzy.fuzzy_collector')
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -147,24 +147,23 @@ endpoint or the `csv` one.
 
     LOG_NOT_FOUND = False
 
-
-#### PROCESSORS_PATHS (iterable of python paths)
+#### PROCESSORS_PYPATHS (iterable of python paths)
 Define the various functions to preprocess the text, before indexing and
 searching. It's an `iterable` of python paths. Some functions are built in
 (mainly for French at this time, but you can point to any python function that
 is on the pythonpath).
 
-    PROCESSORS_PATHS = [
+    PROCESSORS_PYPATHS = [
         'addok.textutils.default.pipeline.tokenize',
         'addok.textutils.default.pipeline.normalize',
         'addok.textutils.default.pipeline.synonymize',
         'addok.textutils.fr.phonemicize',
     ]
 
-#### QUERY_PROCESSORS_PATHS (iterable of python paths)
+#### QUERY_PROCESSORS_PYPATHS (iterable of python paths)
 Additional processors that are run only at query time.
 
-    QUERY_PROCESSORS_PATHS = (
+    QUERY_PROCESSORS_PYPATHS = (
         'addok.textutils.fr_FR.extract_address',
         'addok.textutils.fr_FR.clean_query',
         'addok.textutils.fr_FR.glue_ordinal',
@@ -173,7 +172,7 @@ Additional processors that are run only at query time.
 #### SYNONYMS_PATH (path)
 Path to the synonym file. Synonyms file are in the format `av, ave => avenue`.
 
-    SYNONYMS_PATH = RESOURCES_ROOT.joinpath('synonyms').joinpath('fr.txt')
+    SYNONYMS_PATH = '/path/to/synonyms.txt'
 
 ## Advanced settings
 
@@ -204,15 +203,15 @@ Default score for the relation token to document.
 
     DEFAULT_BOOST = 1.0
 
-#### DOCUMENT_SERIALIZER_PATH (path)
+#### DOCUMENT_SERIALIZER_PYPATH (path)
 Path to the serializer to be used for storing documents. Must have `loads` and
 `dumps` methods.
 
-    DOCUMENT_SERIALIZER_PATH = 'addok.helpers.serializers.ZlibSerializer'
+    DOCUMENT_SERIALIZER_PYPATH = 'addok.helpers.serializers.ZlibSerializer'
 
 For a faster option (but using more RAM), use `marshal` instead.
 
-    DOCUMENT_SERIALIZER_PATH = 'marshal'
+    DOCUMENT_SERIALIZER_PYPATH = 'marshal'
 
 
 #### GEOHASH_PRECISION (int)

--- a/docs/config.md
+++ b/docs/config.md
@@ -147,23 +147,24 @@ endpoint or the `csv` one.
 
     LOG_NOT_FOUND = False
 
-#### PROCESSORS (iterable of python paths)
+
+#### PROCESSORS_PATHS (iterable of python paths)
 Define the various functions to preprocess the text, before indexing and
 searching. It's an `iterable` of python paths. Some functions are built in
 (mainly for French at this time, but you can point to any python function that
 is on the pythonpath).
 
-    PROCESSORS = [
+    PROCESSORS_PATHS = [
         'addok.textutils.default.pipeline.tokenize',
         'addok.textutils.default.pipeline.normalize',
         'addok.textutils.default.pipeline.synonymize',
         'addok.textutils.fr.phonemicize',
     ]
 
-#### QUERY_PROCESSORS (iterable of python paths)
+#### QUERY_PROCESSORS_PATHS (iterable of python paths)
 Additional processors that are run only at query time.
 
-    QUERY_PROCESSORS = (
+    QUERY_PROCESSORS_PATHS = (
         'addok.textutils.fr_FR.extract_address',
         'addok.textutils.fr_FR.clean_query',
         'addok.textutils.fr_FR.glue_ordinal',
@@ -203,15 +204,15 @@ Default score for the relation token to document.
 
     DEFAULT_BOOST = 1.0
 
-#### DOCUMENT_SERIALIZER (path)
+#### DOCUMENT_SERIALIZER_PATH (path)
 Path to the serializer to be used for storing documents. Must have `loads` and
 `dumps` methods.
 
-    DOCUMENT_SERIALIZER = 'addok.helpers.serializers.ZlibSerializer'
+    DOCUMENT_SERIALIZER_PATH = 'addok.helpers.serializers.ZlibSerializer'
 
 For a faster option (but using more RAM), use `marshal` instead.
 
-    DOCUMENT_SERIALIZER = 'marshal'
+    DOCUMENT_SERIALIZER_PATH = 'marshal'
 
 
 #### GEOHASH_PRECISION (int)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -61,14 +61,14 @@ tracker](https://github.com/addok/addok/issues) to ask for help.
 
 And paste this configuration:
 ```
-QUERY_PROCESSORS_PATHS = [
+QUERY_PROCESSORS_PYPATHS = [
     "addok_france.extract_address",
     "addok_france.clean_query",
     "addok_france.remove_leading_zeros",
     "addok_france.glue_ordinal",
     "addok_france.fold_ordinal",
 ]
-SEARCH_RESULT_PROCESSORS_PATHS = [
+SEARCH_RESULT_PROCESSORS_PYPATHS = [
     "addok_france.match_housenumber",
     "addok_france.make_labels",
     "addok.helpers.results.score_by_importance",
@@ -76,7 +76,7 @@ SEARCH_RESULT_PROCESSORS_PATHS = [
     "addok.helpers.results.score_by_ngram_distance",
     "addok.helpers.results.score_by_geo_distance",
 ]
-PROCESSORS_PATHS = [
+PROCESSORS_PYPATHS = [
     "addok.helpers.text.tokenize",
     "addok.helpers.text.normalize",
     "addok_france.glue_ordinal",

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -61,22 +61,22 @@ tracker](https://github.com/addok/addok/issues) to ask for help.
 
 And paste this configuration:
 ```
-QUERY_PROCESSORS = [
+QUERY_PROCESSORS_PATHS = [
     "addok_france.extract_address",
     "addok_france.clean_query",
     "addok_france.remove_leading_zeros",
     "addok_france.glue_ordinal",
     "addok_france.fold_ordinal",
 ]
-SEARCH_RESULT_PROCESSORS = [
-    "addok.helpers.results.match_housenumber",
+SEARCH_RESULT_PROCESSORS_PATHS = [
+    "addok_france.match_housenumber",
     "addok_france.make_labels",
     "addok.helpers.results.score_by_importance",
     "addok.helpers.results.score_by_autocomplete_distance",
     "addok.helpers.results.score_by_ngram_distance",
     "addok.helpers.results.score_by_geo_distance",
 ]
-PROCESSORS = [
+PROCESSORS_PATHS = [
     "addok.helpers.text.tokenize",
     "addok.helpers.text.normalize",
     "addok_france.glue_ordinal",


### PR DESCRIPTION
Still to discuss:

* [x] not particularly fond of the way we have two `resolve_path(s)` methods with in-place update of settings, maybe something more explicit?
* [x] there is an existing `SYNONYMS_PATH` setting which means there will be a somehow polluting `config.SYNONYMS` available, not sure if it breaks once set.
* [x] it conflicts with [PR#225](https://github.com/addok/addok/pull/225)
* [x] plugins require an update too! (see below, update if missing pertinent plugin)
* [x] For addok-sqlite, there is the existing `SQLITE_DB_PATH` too that will be wrongly converted (and `DOCUMENT_STORE` to update), maybe change the name?
* [x] Is addok-psql still relevant now that we split documents between Redis and storage?

Hopefully I didn't miss too much places.