### PR TITLE
Add flush command (fix #235)

### DIFF
--- a/addok/batch.py
+++ b/addok/batch.py
@@ -4,6 +4,8 @@ import sys
 from datetime import timedelta
 
 from addok.config import config
+from addok.db import DB
+from addok.ds import DS
 from addok.helpers import iter_pipe, parallelize, yielder
 
 
@@ -15,11 +17,25 @@ def run(args):
         process_stdin(sys.stdin)
 
 
+def reset(args):
+    if args.force or input('Type "yes" to delete ALL data: ') == 'yes':
+        DB.flushdb()
+        DS.flushdb()
+        print('All data has been deleted.')
+    else:
+        print('Nothing has been deleted.')
+
+
 def register_command(subparsers):
     parser = subparsers.add_parser('batch', help='Batch import documents')
     parser.add_argument('filepath', nargs='*',
                         help='Path to file to process')
     parser.set_defaults(func=run)
+    parser = subparsers.add_parser('reset',
+                                   help='Delete ALL indexes and documents')
+    parser.add_argument('--force', help='Do not ask for confirm',
+                        action='store_true')
+    parser.set_defaults(func=reset)
 
 
 def preprocess_batch(d):

--- a/addok/ds.py
+++ b/addok/ds.py
@@ -25,6 +25,9 @@ class RedisStore:
             pipe.delete(key)
         pipe.execute()
 
+    def flushdb(self):
+        _DB.flushdb()
+
 
 class DSProxy:
     instance = None

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,5 +1,6 @@
-from addok.batch import process_documents
+from addok.batch import process_documents, reset
 from addok.core import search
+from addok.db import DB
 
 
 def test_process_should_index_by_default(factory):
@@ -24,3 +25,29 @@ def test_process_should_update_if_action_is_given(factory):
     process_documents(doc.copy())
     assert search("avenue")
     assert not search("rue")
+
+
+def test_reset(factory, monkeypatch):
+
+    class Args:
+        force = False
+
+    factory(name="rue de l'avoine")
+    assert DB.keys()
+    monkeypatch.setitem(__builtins__, 'input', lambda *args, **kwargs: 'no')
+    reset(Args())
+    assert DB.keys()
+    monkeypatch.setitem(__builtins__, 'input', lambda *args, **kwargs: 'yes')
+    reset(Args())
+    assert not DB.keys()
+
+
+def test_force_reset(factory):
+
+    class Args:
+        force = True
+
+    factory(name="rue de l'avoine")
+    assert DB.keys()
+    reset(Args())
+    assert not DB.keys()


### PR DESCRIPTION
Note: `DS.flush()` will by default with `RedisStore` do nothing, because when doing `DB.flushdb()` we already are deleting the documents.

I'm doing a PR in addok-sqlite too.