### PR TITLE
Restore shell help option, fix #243

### DIFF
--- a/addok/bin/__init__.py
+++ b/addok/bin/__init__.py
@@ -9,12 +9,12 @@ from addok.config import config
 def main():
     main_parser = argparse.ArgumentParser(description='Addok command line.',
                                           add_help=False)
-    main_parser.add_argument('-h', '--help', action='store_true',
-                             help='Show this help message and exit')
     main_parser.add_argument('--config', help='Local config')
     args, extras = main_parser.parse_known_args()
     if args.config:
         os.environ['ADDOK_CONFIG_MODULE'] = args.config
+    main_parser.add_argument('-h', '--help', action='store_true',
+                             help='Show this help message and exit')
 
     subparsers = main_parser.add_subparsers(title='Available commands',
                                             metavar='')

--- a/addok/bin/__init__.py
+++ b/addok/bin/__init__.py
@@ -7,8 +7,10 @@ from addok.config import config
 
 
 def main():
-
-    main_parser = argparse.ArgumentParser(description='Addok command line.')
+    main_parser = argparse.ArgumentParser(description='Addok command line.',
+                                          add_help=False)
+    main_parser.add_argument('-h', '--help', action='store_true',
+                             help='Show this help message and exit')
     main_parser.add_argument('--config', help='Local config')
     args, extras = main_parser.parse_known_args()
     if args.config:


### PR DESCRIPTION
As crazy as it seems, you have to specify the help option by hand when you use `parse_known_args` otherwise its implicitness is not considered as know by the parser.