### PR TITLE
Remove HOUSENUMBER_PAYLOADS_FIELDS, fix #248

### DIFF
--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -109,10 +109,6 @@ FIELDS = [
 # Sometimes you only want to add some fields keeping the default ones.
 EXTRA_FIELDS = []
 
-# If you want to store extra fields with each housenumber. Those fields will
-# not be searchable, but will be returned in the search result.
-HOUSENUMBERS_PAYLOAD_FIELDS = []
-
 # Weight of a document own importance:
 IMPORTANCE_WEIGHT = 0.1
 

--- a/addok/core.py
+++ b/addok/core.py
@@ -68,16 +68,13 @@ class Result:
 
     @property
     def keys(self):
-        to_filter = ['importance', 'housenumbers', 'lat', 'lon']
-        keys = ['housenumber']
-        keys.extend(self._doc.keys())
-        housenumber = getattr(self, 'housenumber', None)
-        if housenumber:
-            keys.extend(config.HOUSENUMBERS_PAYLOAD_FIELDS)
-        for key in keys:
-            if key.startswith(('_', 'h|')) or key in to_filter:
-                continue
-            yield key
+        keys = ['housenumber'] + list(self._doc.keys())
+        # housenumbers are too verbose for a given street.
+        yield from (key for key in keys if key != 'housenumbers')
+
+    def update(self, data):
+        self._doc.update(data)
+        self._cache.update(data)
 
     def format(self):
         result = self

--- a/addok/helpers/formatters.py
+++ b/addok/helpers/formatters.py
@@ -6,7 +6,7 @@ def geojson(result):
         properties["score"] = result.score
     for key in result.keys:
         val = getattr(result, key, None)
-        if val:
+        if val and key not in ['lat', 'lon']:
             properties[key] = val
     housenumber = getattr(result, 'housenumber', None)
     if housenumber:

--- a/addok/helpers/results.py
+++ b/addok/helpers/results.py
@@ -34,7 +34,7 @@ def _match_housenumber(helper, result, tokens):
             data = result.housenumbers[str(token)]
             result.housenumber = data.pop('raw')
             result.type = 'housenumber'
-            result._cache.update(data)
+            result.update(data)
             break
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -153,12 +153,6 @@ filter means bigger index.
 
     FILTERS = ["type", "postcode"]
 
-#### HOUSENUMBERS_PAYLOAD_FIELDS (list of keys)
-If you want to store extra fields with each payload. Those fields will not
-be searchable, but will be returned in the search result.
-
-    HOUSENUMBERS_PAYLOAD_FIELDS = ['key1', 'key2']
-
 #### LICENCE (string or dict)
 The licence of the data returned by the API. Can be a simple string, or a dict.
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -17,7 +17,12 @@ The expected keys are the ones declared in the `FIELDS` attribute of your
 - **id** is expected
 - **lat** and **lon** are expected
 - **housenumbers** has a special format: `{number: {lat: yyy, lon: xxx}}` (optionally you can
-  add an `id` key for each housenumber entry)
+  add any custom attribute)
+
+Each value can be either a unique value or a list of values. In the latter case,
+the first value will be considered as the active one (for example to display the label),
+the optional other ones are considered as aliases.
+They will be indexed and searchable though.
 
 #### Example
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -125,7 +125,6 @@ def test_view_should_expose_config(config):
 
 
 def test_geojson_should_return_housenumber_payload(client, factory, config):
-    config.HOUSENUMBERS_PAYLOAD_FIELDS = ['key']
     factory(name="rue de Paris", type="street", id="123",
             housenumbers={'1': {'lat': '48.32', 'lon': '2.25', 'key': 'abc'}})
     resp = client.get('/search/', query_string={'q': 'rue de paris'})

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -283,7 +283,6 @@ def test_housenumber_are_not_computed_if_another_type_is_asked(factory):
 
 
 def test_housenumbers_payload_fields_are_exported(config, factory):
-    config.HOUSENUMBERS_PAYLOAD_FIELDS = ['key']
     factory(name="rue de Paris", type="street", id="123",
             housenumbers={'1': {'lat': '48.32', 'lon': '2.25', 'key': 'abc'}})
     results = search("rue de paris")
@@ -293,7 +292,6 @@ def test_housenumbers_payload_fields_are_exported(config, factory):
 
 
 def test_id_is_overwritten_when_given_in_housenumber_payload(config, factory):
-    config.HOUSENUMBERS_PAYLOAD_FIELDS = ['id']
     factory(name="rue de Paris", type="street", id="123",
             housenumbers={'1': {'lat': '48.325', 'lon': '2.256', 'id': 'abc'}})
     results = search("rue de paris")
@@ -303,7 +301,6 @@ def test_id_is_overwritten_when_given_in_housenumber_payload(config, factory):
 
 
 def test_postcode_is_overwritten_when_in_housenumber_payload(config, factory):
-    config.HOUSENUMBERS_PAYLOAD_FIELDS = ['postcode']
     factory(name="rue de Paris", type="street", id="123", postcode="12345",
             housenumbers={'1': {'lat': '48.325', 'lon': '2.256',
                                 'postcode': '54321'}})
@@ -311,16 +308,6 @@ def test_postcode_is_overwritten_when_in_housenumber_payload(config, factory):
     assert results[0].postcode == '12345'
     results = search("1 rue de paris")
     assert results[0].postcode == '54321'
-
-
-def test_unknown_key_in_housenumber_payload_does_not_fail(config, factory):
-    config.HOUSENUMBERS_PAYLOAD_FIELDS = ['xxxyyy']
-    factory(name="rue de Paris", type="street", id="123", postcode="12345",
-            housenumbers={'1': {'lat': '48.325', 'lon': '2.256'}})
-    results = search("rue de paris")
-    assert results[0].id == '123'
-    results = search("1 rue de paris")
-    assert results[0].id == '123'
 
 
 def test_from_id(factory):


### PR DESCRIPTION
It’s a useless setting now, all housenumbers properties will be exported.