### PR TITLE
use os.path instead of Path.home() to avoid python 3.5 dependency

### DIFF
--- a/addok/shell.py
+++ b/addok/shell.py
@@ -56,7 +56,7 @@ class Cmd(cmd.Cmd):
 
     @property
     def history_file(self):
-        return str(os.path.expanduser('~')+'/'+self.HISTORY_FILE)
+        return str(os.path.join(os.path.expanduser('~'),self.HISTORY_FILE))
 
     def error(self, message):
         print(red(message))

--- a/addok/shell.py
+++ b/addok/shell.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 import time
-from pathlib import Path
+import os
 
 import geohash
 from progressist import Formatter
@@ -56,7 +56,7 @@ class Cmd(cmd.Cmd):
 
     @property
     def history_file(self):
-        return str(Path.home() / self.HISTORY_FILE)
+        return str(os.path.expanduser('~')+'/'+self.HISTORY_FILE)
 
     def error(self, message):
         print(red(message))

--- a/addok/shell.py
+++ b/addok/shell.py
@@ -56,7 +56,7 @@ class Cmd(cmd.Cmd):
 
     @property
     def history_file(self):
-        return str(os.path.join(os.path.expanduser('~'),self.HISTORY_FILE))
+        return os.path.join(os.path.expanduser('~'), self.HISTORY_FILE)
 
     def error(self, message):
         print(red(message))


### PR DESCRIPTION
Path.home() does not always return valid home directory
