### PR TITLE
Do not extend meaningful with common if there are filters

### DIFF
--- a/addok/helpers/collectors.py
+++ b/addok/helpers/collectors.py
@@ -40,7 +40,7 @@ def only_commons(helper):
 def bucket_with_meaningful(helper):
     if not helper.meaningful:
         return
-    if len(helper.meaningful) == 1 and helper.common:
+    if len(helper.meaningful) == 1 and helper.common and not helper.filters:
         # Avoid running with too less tokens while having commons terms.
         for token in helper.common:
             if token not in helper.meaningful:


### PR DESCRIPTION
We try to limit the number of false positive, which is already done
by the filter, incidentally.

#296 really is a edge case, but still we can make the "extend meaningful" step a bit smarter.