### PR TITLE
Use hashids for smaller keys and less memory usage, fix #288

### DIFF
--- a/addok/core.py
+++ b/addok/core.py
@@ -103,7 +103,7 @@ class Result:
 
     @classmethod
     def from_id(self, _id):
-        """Return a result from it's document id."""
+        """Return a result from it's document _id."""
         return Result(keys.document_key(_id))
 
 

--- a/addok/db.py
+++ b/addok/db.py
@@ -1,6 +1,10 @@
 import redis
+from hashids import Hashids
 
 from addok.config import config
+
+
+hashids = Hashids()
 
 
 class RedisProxy:
@@ -12,6 +16,10 @@ class RedisProxy:
 
     def __getattr__(self, name):
         return getattr(self.instance, name)
+
+    def next_id(self):
+        next_id = self.incr('_id_sequence')
+        return hashids.encode(next_id)
 
 
 DB = RedisProxy()

--- a/addok/ds.py
+++ b/addok/ds.py
@@ -1,5 +1,5 @@
 from addok.config import config
-from addok.db import RedisProxy
+from addok.db import DB, RedisProxy
 from addok.helpers import keys
 
 
@@ -56,7 +56,9 @@ def store_documents(docs):
     for doc in docs:
         if not doc:
             continue
-        key = keys.document_key(doc['id'])
+        if '_id' not in doc:
+            doc['_id'] = DB.next_id()
+        key = keys.document_key(doc['_id'])
         if doc.get('_action') in ['delete', 'update']:
             to_remove.append(key)
         if doc.get('_action') in ['index', 'update', None]:

--- a/addok/helpers/index.py
+++ b/addok/helpers/index.py
@@ -58,7 +58,7 @@ def index_documents(docs):
         if not doc:
             continue
         if doc.get('_action') in ['delete', 'update']:
-            key = keys.document_key(doc['id']).encode()
+            key = keys.document_key(doc['_id']).encode()
             known_doc = get_document(key)
             if known_doc:
                 deindex_document(known_doc)
@@ -73,7 +73,7 @@ def index_documents(docs):
 
 
 def index_document(pipe, doc, **kwargs):
-    key = keys.document_key(doc['id'])
+    key = keys.document_key(doc['_id'])
     tokens = {}
     for indexer in config.INDEXERS:
         try:
@@ -84,7 +84,7 @@ def index_document(pipe, doc, **kwargs):
 
 
 def deindex_document(doc, **kwargs):
-    key = keys.document_key(doc['id'])
+    key = keys.document_key(doc['_id'])
     tokens = []
     for indexer in config.INDEXERS:
         indexer.deindex(DB, key, doc, tokens, **kwargs)

--- a/addok/pytest.py
+++ b/addok/pytest.py
@@ -9,16 +9,17 @@ from pathlib import Path
 import uuid
 
 import pytest
+# Do not import files from the top of the module, otherwise they will
+# not be taken into account by the coverage.
 
 
 def pytest_configure():
-    # Do not import files from the top of the module, otherwise they will
-    # not taken into account by the coverage.
     from addok.config import config as addok_config
     addok_config.__class__.TESTING = True
     # Force test config.
     from addok import config as config_module
-    os.environ['ADDOK_CONFIG_MODULE'] = str(Path(config_module.__file__).parent / 'test.py')
+    os.environ['ADDOK_CONFIG_MODULE'] = str(
+        Path(config_module.__file__).parent / 'test.py')
     import logging
     logging.basicConfig(level=logging.DEBUG)
     addok_config.REDIS['indexes']['db'] = 14
@@ -76,9 +77,12 @@ class DummyDoc(dict):
 
 @pytest.fixture
 def factory(request):
+    from addok import db
+
     def _(**kwargs):
         default = {
             'id': uuid.uuid4().hex,
+            '_id': db.DB.next_id(),
             'type': 'street',
             'name': 'ellington',
             'importance': 0.0,

--- a/addok/shell.py
+++ b/addok/shell.py
@@ -173,13 +173,13 @@ class Cmd(cmd.Cmd):
         def format_scores(result):
             if verbose or bucket:
                 return (', '.join('{}: {}/{}'.format(k, round(v[0], 4), v[1])
-                        for k, v in result._scores.items()))
+                                  for k, v in result._scores.items()))
             else:
                 return result.score
 
         for result in results:
             print('{} ({} | {})'.format(white(result),
-                                        blue(result.id),
+                                        blue(result._id),
                                         blue(format_scores(result))))
         formatter = red if duration > 50 else green
         print('{} — {} — {}'.format(formatter("{} ms".format(duration)),

--- a/docs/import.md
+++ b/docs/import.md
@@ -14,7 +14,7 @@ The expected keys are the ones declared in the `FIELDS` attribute of your
 
 - **type** is expected even if not declared as index field
 - **importance** is expected; must be a `float` between 0 and 1
-- **id** is expected
+- **_id** is optional and for internal use only, if not present a [hashid](http://hashids.org/) will be generated; note that shorter keys lead to smaller memory consumption on the Redis side
 - **lat** and **lon** are expected
 - **housenumbers** has a special format: `{number: {lat: yyy, lon: xxx}}` (optionally you can
   add any custom attribute)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 falcon==1.1.0
+hashids==1.2.0
 hiredis==0.2.0
 ngram==3.3.0
 progressist==0.0.6

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -15,7 +15,10 @@ def test_process_should_index_by_default(factory):
 def test_process_should_deindex_if_action_is_given(factory):
     doc = factory(name="Mélicocq")
     assert search("Mélicoq")
-    process_documents(json.dumps({"_action": "delete", "id": doc["id"]}))
+    process_documents(json.dumps({
+        "_action": "delete",
+        "_id": doc["_id"]
+    }))
     assert not search("Mélicoq")
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -116,8 +116,8 @@ def test_reverse_without_lat_or_lng_should_return_400(client, factory):
 
 
 def test_get_endpoint(client, factory):
-    factory(name='sentier de la côte', id='123')
-    resp = client.get('/get/123')
+    doc = factory(name='sentier de la côte', id='123')
+    resp = client.get('/get/{doc_id}'.format(doc_id=doc['_id']))
     assert resp.json['properties']['id'] == '123'
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -8,8 +8,8 @@ def test_manual_scan(factory):
     street2 = factory(name="rue de la monnaie", city="Condom", importance=0.9)
     results = scripts.manual_scan(keys=['w|monnaie', 'w|rue', 'w|de'],
                                   args=[2])
-    assert results == ['d|{}'.format(street1['id']).encode(),
-                       'd|{}'.format(street2['id']).encode()]
+    assert results == ['d|{}'.format(street1['_id']).encode(),
+                       'd|{}'.format(street2['_id']).encode()]
 
 
 def test_zinter(factory):
@@ -21,10 +21,10 @@ def test_zinter(factory):
     )
     results = scripts.zinter(keys=['w|monnaie', 'w|rue', 'w|de'],
                              args=['tmp', 2])
-    assert results == ['d|{}'.format(docs[2]['id']).encode(),
-                       'd|{}'.format(docs[3]['id']).encode()]
+    assert results == ['d|{}'.format(docs[2]['_id']).encode(),
+                       'd|{}'.format(docs[3]['_id']).encode()]
     results = scripts.zinter(keys=['w|monnaie', 'w|rue', 'w|de'],
                              args=['tmp', 3])
-    assert results == ['d|{}'.format(docs[2]['id']).encode(),
-                       'd|{}'.format(docs[3]['id']).encode(),
-                       'd|{}'.format(docs[0]['id']).encode()]
+    assert results == ['d|{}'.format(docs[2]['_id']).encode(),
+                       'd|{}'.format(docs[3]['_id']).encode(),
+                       'd|{}'.format(docs[0]['_id']).encode()]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -322,9 +322,9 @@ def test_postcode_is_overwritten_when_in_housenumber_payload(config, factory):
 
 
 def test_from_id(factory):
-    factory(name="avenue de Paris", type="street", id="123")
-    doc = Result.from_id("123")
-    assert doc.id == "123"
+    doc = factory(name="avenue de Paris", type="street", id="123")
+    result = Result.from_id(doc['_id'])
+    assert result.id == "123"
 
 
 def test_should_compare_with_multiple_values(city, factory):


### PR DESCRIPTION
Loading `BAN_odbl_76-json`:

Before (master): `Done: 35023 | Elapsed: 0:01:16 | 1m 20s 349ms`

with:

```
> DBINFO
keyspace_misses: 62433
keyspace_hits: 4453
used_memory_human: 297.95M
total_commands_processed: 9859055
total_connections_received: 83
connected_clients: 1
nb keys (db 0): 108358
nb keys (db 1): 35023
```

After: `Done: 35023 | Elapsed: 0:01:08 | 1m 12s 522ms`

with:

```
> DBINFO
keyspace_misses: 62433
keyspace_hits: 4453
used_memory_human: 279.78M
total_commands_processed: 5006893
total_connections_received: 66
connected_clients: 1
nb keys (db 0): 108359
nb keys (db 1): 35023
```

The benchmark is not really relevant from one run to another but we don't have a significative loss. The memory has reduced 🎉 and the difference will be more important with more keys!

I wonder if the `_` (underscore) to prefix `hashid` is pertinent.