### PR TITLE
Revert "Rename `batch` to `load` even in settings"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 ## 1.0.0-dev
 
-- rename the `batch` shell command to `import` and `BATCH_*` settings to
-  `IMPORT_*`.
-
-## 1.0.0-rc.2
-
 - remove `DOCUMENT_PROCESSORS_PYPATHS` in favor of `BATCH_PROCESSORS_PYPATHS`
   (not in use before 1.0.0-rc.1)
 - add `BATCH_FILE_LOADER_PYPATH` to specify a custom file loader (e.g. msgpack)

--- a/addok/batch.py
+++ b/addok/batch.py
@@ -27,7 +27,7 @@ def reset(args):
 
 
 def register_command(subparsers):
-    parser = subparsers.add_parser('import', help='Load documents')
+    parser = subparsers.add_parser('batch', help='Batch import documents')
     parser.add_argument('filepath', nargs='*',
                         help='Path to file to process')
     parser.set_defaults(func=run)
@@ -45,12 +45,12 @@ def process_file(filepath):
         sys.stderr.write('File not found: {}'.format(filepath))
         sys.exit(1)
     config.INDEX_EDGE_NGRAMS = False  # Run command "ngrams" instead.
-    load(config.IMPORT_FILE_LOADER(filepath))
+    batch(config.BATCH_FILE_LOADER(filepath))
 
 
 def process_stdin(stdin):
     print('Import from stdin')
-    load(stdin)
+    batch(stdin)
 
 
 @yielder
@@ -62,10 +62,10 @@ def to_json(row):
 
 
 def process_documents(*docs):
-    return list(iter_pipe(docs, config.IMPORT_PROCESSORS))
+    return list(iter_pipe(docs, config.BATCH_PROCESSORS))
 
 
-def load(iterable):
+def batch(iterable):
     parallelize(process_documents, iterable,
-                chunk_size=config.IMPORT_CHUNK_SIZE,
+                chunk_size=config.BATCH_CHUNK_SIZE,
                 throttle=timedelta(seconds=1))

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -50,17 +50,17 @@ SEARCH_PREPROCESSORS_PYPATHS = [
     'addok.helpers.search.select_tokens',
     'addok.helpers.search.set_should_match_threshold',
 ]
-IMPORT_PROCESSORS_PYPATHS = [
+BATCH_PROCESSORS_PYPATHS = [
     'addok.batch.to_json',
     'addok.helpers.index.prepare_housenumbers',
     'addok.ds.store_documents',
     'addok.helpers.index.index_documents',
 ]
-IMPORT_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
-IMPORT_CHUNK_SIZE = 1000
+BATCH_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
+BATCH_CHUNK_SIZE = 1000
 # During imports, workers are consuming RAM;
 # let one process free for Redis by default.
-IMPORT_WORKERS = os.cpu_count() - 1
+BATCH_WORKERS = os.cpu_count() - 1
 RESULTS_COLLECTORS_PYPATHS = [
     'addok.helpers.collectors.only_commons',
     'addok.helpers.collectors.bucket_with_meaningful',

--- a/addok/helpers/__init__.py
+++ b/addok/helpers/__init__.py
@@ -158,7 +158,7 @@ class ChunkedPool(Pool):
 
 def parallelize(func, iterable, chunk_size, **bar_kwargs):
     bar = Bar(prefix='Processing…', **bar_kwargs)
-    with ChunkedPool(processes=config.IMPORT_WORKERS) as pool:
+    with ChunkedPool(processes=config.BATCH_WORKERS) as pool:
         for chunk in pool.imap_unordered(func, iterable, chunk_size):
             bar(step=len(chunk))
         bar.finish()

--- a/docs/config.md
+++ b/docs/config.md
@@ -92,33 +92,33 @@ simple string, or a dict.
     # Or
     ATTRIBUTION = {source: attribution, source2: attribution2}
 
-#### IMPORT_CHUNK_SIZE (int)
+#### BATCH_CHUNK_SIZE (int)
 Number of documents to be processed together by each worker during import.
 
-    IMPORT_CHUNK_SIZE = 1000
+    BATCH_CHUNK_SIZE = 1000
 
 
-#### IMPORT_FILE_LOADER_PYPATH (Python path)
+#### BATCH_FILE_LOADER_PYPATH (Python path)
 Python path to a callable which will be responsible of loading file on
 import and return an iterable.
 
-    IMPORT_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
+    BATCH_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
 
-#### IMPORT_PROCESSORS_PYPATHS (iterable of Python paths)
-All methods called during the import process.
+#### BATCH_PROCESSORS_PYPATHS (iterable of Python paths)
+All methods called during the batch process.
 
-    IMPORT_PROCESSORS_PYPATHS = [
+    BATCH_PROCESSORS_PYPATHS = [
         'addok.batch.to_json',
         'addok.helpers.index.prepare_housenumbers',
         'addok.ds.store_documents',
         'addok.helpers.index.index_documents',
     ]
 
-#### IMPORT_WORKERS (int)
-Number of processes in use when parallelizing tasks such as imports or
+#### BATCH_WORKERS (int)
+Number of processes in use when parallelizing tasks such as batch imports or
 ngrams computing.
 
-    IMPORT_WORKERS = os.cpu_count() - 1
+    BATCH_WORKERS = os.cpu_count() - 1
 
 #### DOCUMENT_STORE_PYPATH (Python path)
 Python path to a store class for saving documents using another database

--- a/docs/import.md
+++ b/docs/import.md
@@ -45,7 +45,7 @@ Make sure to check the [Redis tuning tips](redis.md).
 #### Command line
 To run the actual import:
 
-    addok import path/to/file.sjson
+    addok batch path/to/file.sjson
 
 Then you need to index ngrams:
 
@@ -57,9 +57,9 @@ Then you need to index ngrams:
 1. Download [BANO data](http://bano.openstreetmap.fr/data/full.sjson.gz) and
    uncompress it
 
-2. Run import command:
+2. Run batch command:
 
-        addok import path/to/full.sjson
+        addok batch path/to/full.sjson
 
 3. Index edge ngrams:
 
@@ -81,11 +81,11 @@ See [addok-psql](https://github.com/addok/addok-psql) plugin.
 
 `import` command can read from stdin, for example:
 
-    $ addok import < ~/Data/geo/ban/communes-context.json
+    $ addok batch < ~/Data/geo/ban/communes-context.json
 
 Or:
 
-    $ less ~/Data/geo/ban/communes-context.json | addok import
+    $ less ~/Data/geo/ban/communes-context.json | addok batch
 
 ## More options
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -102,7 +102,7 @@ This is for Seine-Saint-Denis, but choose the area you want from the
 
 Run those two commands:
 
-    addok import BAN_odbl_93-json
+    addok batch BAN_odbl_93-json
     addok ngrams
 
 Let's test that everything is ok. Run the addok shell:


### PR DESCRIPTION
Reverts addok/addok#304

Ref: https://github.com/addok/addok/commit/0c23bbc51dbfa67b33085a610ed43320246b1829

As discussed, the command can also "delete" documents, so "import" is not that appropriated. Let's stay with batch for now.