### PR TITLE
Do not index housenumbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-rc.4
+
+- housenumbers are not indexed anymore (to gain RAM), they are only matched in
+  result postprocessing
+- for `addok-france` users: `addok_france.match_housenumber` should be replaced
+  by `addok.helpers.text.match_housenumber` in SEARCH_RESULT_PROCESSORS_PYPATHS
+- new `MIN_SCORE` setting to filter out results with very low scores
+- for `addok-france` users: fixed leading zeros wrongly removed from postcodes
+
 ## 1.0.0-rc.3
 
 - remove `DOCUMENT_PROCESSORS_PYPATHS` in favor of `BATCH_PROCESSORS_PYPATHS`

--- a/addok/autocomplete.py
+++ b/addok/autocomplete.py
@@ -115,8 +115,9 @@ def index_ngram_keys(*keys):
 
 
 def create_edge_ngrams(*args):
-    parallelize(index_ngram_keys, DB.scan_iter(match='w|*'), chunk_size=10000,
-                throttle=1000)
+    pattern = '{}*'.format(dbkeys.TOKEN_PREFIX)
+    parallelize(index_ngram_keys, DB.scan_iter(match=pattern),
+                chunk_size=10000, throttle=1000)
 
 
 def register_command(subparsers):

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -25,6 +25,9 @@ INTERSECT_LIMIT = 100000
 # Min score considered matching the query.
 MATCH_THRESHOLD = 0.9
 
+# Do not consider result if final score is below this threshold.
+MIN_SCORE = 0.1
+
 QUERY_MAX_LENGTH = 200
 
 GEOHASH_PRECISION = 7
@@ -38,6 +41,7 @@ SYNONYMS_PATH = None
 PROCESSORS_PYPATHS = [  # Rename in TOKEN_PROCESSORS / STRING_PROCESSORS?
     'addok.helpers.text.tokenize',
     'addok.helpers.text.normalize',
+    'addok.helpers.text.flag_housenumber',
     'addok.helpers.text.synonymize',
 ]
 QUERY_PROCESSORS_PYPATHS = [
@@ -62,6 +66,8 @@ BATCH_CHUNK_SIZE = 1000
 # let one process free for Redis by default.
 BATCH_WORKERS = os.cpu_count() - 1
 RESULTS_COLLECTORS_PYPATHS = [
+    'addok.helpers.collectors.no_tokens_but_housenumbers_and_geohash',
+    'addok.helpers.collectors.no_available_tokens_abort',
     'addok.helpers.collectors.only_commons',
     'addok.helpers.collectors.bucket_with_meaningful',
     'addok.helpers.collectors.reduce_with_other_commons',

--- a/addok/helpers/collectors.py
+++ b/addok/helpers/collectors.py
@@ -6,6 +6,16 @@ from addok.helpers import scripts
 from addok.pairs import pair_key
 
 
+def no_tokens_but_housenumbers_and_geohash(helper):
+    if not helper.tokens and helper.housenumbers and helper.geohash_key:
+        helper.new_bucket([helper.geohash_key], config.BUCKET_MIN)
+
+
+def no_available_tokens_abort(helper):
+    if not helper.tokens:
+        return True  # Stop processing.
+
+
 def only_commons(helper):
     if len(helper.tokens) == len(helper.common):
         # Only common terms, shortcut to search

--- a/addok/helpers/index.py
+++ b/addok/helpers/index.py
@@ -161,18 +161,14 @@ class HousenumbersIndexer:
     @staticmethod
     def index(pipe, key, doc, tokens, **kwargs):
         housenumbers = doc.get('housenumbers', {})
-        to_index = {}
         for number, data in housenumbers.items():
-            to_index[number] = config.DEFAULT_BOOST
             index_geohash(pipe, key, data['lat'], data['lon'])
-        index_tokens(pipe, to_index, key, **kwargs)
 
     @staticmethod
     def deindex(db, key, doc, tokens, **kwargs):
         housenumbers = doc.get('housenumbers', {})
         for token, data in housenumbers.items():
             deindex_geohash(key, data['lat'], data['lon'])
-            deindex_token(key, token)
 
 
 class FiltersIndexer:

--- a/addok/helpers/keys.py
+++ b/addok/helpers/keys.py
@@ -1,5 +1,8 @@
+TOKEN_PREFIX = 'w|'
+
+
 def token_key(s):
-    return 'w|{}'.format(s)
+    return '{}{}'.format(TOKEN_PREFIX, s)
 
 
 def document_key(s):

--- a/addok/helpers/results.py
+++ b/addok/helpers/results.py
@@ -29,13 +29,15 @@ def match_housenumber(helper, result):
 def _match_housenumber(helper, result, tokens):
     if not helper.check_housenumber:
         return
-    for token in sorted(tokens, key=lambda t: t.position):
-        if token in result.housenumbers:
-            data = result.housenumbers[str(token)]
-            result.housenumber = data.pop('raw')
-            result.type = 'housenumber'
-            result.update(data)
-            break
+    # Housenumber may have multiple tokens (eg. "dix huit"), we join
+    # those to match the way they have been processed by
+    # addok.helpers.index.prepare_housenumbers.
+    raw = ''.join(sorted(helper.housenumbers, key=lambda t: t.position))
+    if raw and raw in result.housenumbers:
+        data = result.housenumbers[str(raw)]
+        result.housenumber = data.pop('raw')
+        result.type = 'housenumber'
+        result.update(data)
 
 
 def score_by_importance(helper, result):

--- a/addok/helpers/search.py
+++ b/addok/helpers/search.py
@@ -26,13 +26,19 @@ def set_should_match_threshold(helper):
 
 
 def select_tokens(helper):
+    tokens = []
     for token in helper.tokens:
-        if token.is_common:
+        if token.kind == 'housenumber':
+            helper.housenumbers.append(token)
+            continue  # Remove from tokens (housenumbers are not indexed).
+        elif token.is_common:
             helper.common.append(token)
         elif token.db_key:
             helper.meaningful.append(token)
         else:
             helper.not_found.append(token)
+        tokens.append(token)
+    helper.tokens = tokens
     helper.common.sort(key=lambda x: x.frequency)
     helper.meaningful.sort(key=lambda x: x.frequency)
     # Sanity limit.

--- a/addok/helpers/test_search_result_processors.py
+++ b/addok/helpers/test_search_result_processors.py
@@ -1,0 +1,42 @@
+import json
+
+import pytest
+
+from addok.batch import process_documents
+from addok.core import search
+
+
+@pytest.mark.parametrize("input,expected", [
+    ('rue du 8 mai troyes', False),
+    ('8 rue du 8 mai troyes', '8'),
+    ('3 rue du 8 mai troyes', '3'),
+])
+def test_match_housenumber(input, expected):
+    doc = {
+        'id': 'xxxx',
+        '_id': 'yyyy',
+        'type': 'street',
+        'name': 'rue du 8 Mai',
+        'city': 'Troyes',
+        'lat': '49.32545',
+        'lon': '4.2565',
+        'housenumbers': {
+            '3': {
+                'lat': '48.325451',
+                'lon': '2.25651'
+            },
+            '3 bis': {
+                'lat': '48.325451',
+                'lon': '2.25651'
+            },
+            '8': {
+                'lat': '48.325451',
+                'lon': '2.25651'
+            },
+        }
+    }
+    process_documents(json.dumps(doc))
+    result = search(input)[0]
+    assert (result.type == 'housenumber') == bool(expected)
+    if expected:
+        assert result.housenumber == expected

--- a/addok/helpers/text.py
+++ b/addok/helpers/text.py
@@ -187,3 +187,14 @@ def check_query_length(q):
         raise EntityTooLarge('Query too long, {} chars, limit is {}'.format(
             len(q), config.QUERY_MAX_LENGTH))
     return q
+
+
+@yielder
+def flag_housenumber(token):
+    """Very basic housenumber flagging. Make your own for your specific needs.
+    Eg. in addok-france:
+    https://github.com/addok/addok-france/blob/master/addok_france/utils.py#L106
+    """
+    if token.is_first and token.isdigit():
+        token.kind = 'housenumber'
+    return token

--- a/addok/pairs.py
+++ b/addok/pairs.py
@@ -1,7 +1,5 @@
-from addok.config import config
 from addok.db import DB
 from addok.helpers import keys, magenta, white
-from addok.helpers.index import preprocess
 from addok.helpers.search import preprocess_query
 
 
@@ -13,26 +11,14 @@ class PairsIndexer:
 
     @staticmethod
     def index(pipe, key, doc, tokens, **kwargs):
-        tokens = list(set(tokens.keys()))  # Unique values.
-        housenumber_pairs = set()
-        housenumbers = doc.get(config.HOUSENUMBERS_FIELD)
-        if housenumbers:
-            for number in housenumbers.keys():
-                for token in preprocess(number):
-                    # Pair every document term to each housenumber, but do not
-                    # pair housenumbers together.
-                    pipe.sadd(pair_key(token), *tokens)
-                    housenumber_pairs.add(token)
-        for token in tokens:
+        for token in list(set(tokens.keys())):  # Unique values.
             pairs = set(t for t in tokens if t != token)
-            pairs.update(housenumber_pairs)
             if pairs:
                 pipe.sadd(pair_key(token), *pairs)
 
     @staticmethod
     def deindex(db, key, doc, tokens, **kwargs):
-        housenumbers = doc.get('housenumbers', {})
-        tokens = list(set(tokens + list(housenumbers.keys())))  # Deduplicate.
+        tokens = list(set(tokens))  # Unique values.
         for i, token in enumerate(tokens):
             for token2 in tokens[i:]:
                 if token != token2:

--- a/docs/config.md
+++ b/docs/config.md
@@ -92,28 +92,6 @@ simple string, or a dict.
     # Or
     ATTRIBUTION = {source: attribution, source2: attribution2}
 
-#### BATCH_CHUNK_SIZE (int)
-Number of documents to be processed together by each worker during import.
-
-    BATCH_CHUNK_SIZE = 1000
-
-
-#### BATCH_FILE_LOADER_PYPATH (Python path)
-Python path to a callable which will be responsible of loading file on
-import and return an iterable.
-
-    BATCH_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
-
-#### BATCH_PROCESSORS_PYPATHS (iterable of Python paths)
-All methods called during the batch process.
-
-    BATCH_PROCESSORS_PYPATHS = [
-        'addok.batch.to_json',
-        'addok.helpers.index.prepare_housenumbers',
-        'addok.ds.store_documents',
-        'addok.helpers.index.index_documents',
-    ]
-
 #### BATCH_WORKERS (int)
 Number of processes in use when parallelizing tasks such as batch imports or
 ngrams computing.
@@ -184,26 +162,6 @@ processed.
 
     QUERY_MAX_LENGTH = 200
 
-#### PROCESSORS_PYPATHS (iterable of Python paths)
-Define the various functions to preprocess the text, before indexing and
-searching. It's an `iterable` of Python paths. Some functions are built in
-(mainly for French at this time, but you can point to any Python function that
-is on the pythonpath).
-
-    PROCESSORS_PYPATHS = [
-        'addok.helpers.text.tokenize',
-        'addok.helpers.text.normalize',
-        'addok.helpers.text.synonymize',
-    ]
-
-#### QUERY_PROCESSORS_PYPATHS (iterable of Python paths)
-Additional processors that are run only at query time. By default, only
-`check_query_length` is active, it depends on `QUERY_MAX_LENGTH` to avoid DoS.
-
-    QUERY_PROCESSORS_PYPATHS = (
-        'addok.helpers.text.check_query_length',
-    )
-
 #### SYNONYMS_PATH (path)
 Path to the synonym file. Synonyms file are in the format `av, ave => avenue`.
 
@@ -212,6 +170,27 @@ Path to the synonym file. Synonyms file are in the format `av, ave => avenue`.
 ## Advanced settings
 
 Those are internal settings. Change them with caution.
+
+#### BATCH_CHUNK_SIZE (int)
+Number of documents to be processed together by each worker during import.
+
+    BATCH_CHUNK_SIZE = 1000
+
+#### BATCH_FILE_LOADER_PYPATH (Python path)
+Python path to a callable which will be responsible of loading file on
+import and return an iterable.
+
+    BATCH_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
+
+#### BATCH_PROCESSORS_PYPATHS (iterable of Python paths)
+All methods called during the batch process.
+
+    BATCH_PROCESSORS_PYPATHS = [
+        'addok.batch.to_json',
+        'addok.helpers.index.prepare_housenumbers',
+        'addok.ds.store_documents',
+        'addok.helpers.index.index_documents',
+    ]
 
 #### BUCKET_MIN (int)
 The min number of items addok will try to fetch from Redis before scoring and
@@ -248,7 +227,6 @@ For a faster option (but using more RAM), use `marshal` instead.
 
     DOCUMENT_SERIALIZER_PYPATH = 'marshal'
 
-
 #### GEOHASH_PRECISION (int)
 Size of the geohash. The bigger the setting, the smaller the hash.
 See [Geohash on Wikipedia](http://en.wikipedia.org/wiki/Geohash).
@@ -275,6 +253,12 @@ Minimum length of computed edge ngrams.
 
     MIN_EDGE_NGRAMS = 3
 
+#### MIN_SCORE (float)
+All results with final score below this threshold will not be kept. Score is
+between 0 and 1.
+
+    MIN_SCORE = 0.1
+
 #### MAKE_LABELS (func)
 Function to override labels built for string comparison with query
 at scoring time. Takes a `result` object as argument and must return a
@@ -286,3 +270,50 @@ list of strings.
 Min score used to consider a result may *match* the query.
 
     MATCH_THRESHOLD = 0.9
+
+#### PROCESSORS_PYPATHS (iterable of Python paths)
+Define the various functions to preprocess the text, before indexing and
+searching. It's an `iterable` of Python paths. Some functions are built in
+(mainly for French at this time, but you can point to any Python function that
+is on the pythonpath).
+
+    PROCESSORS_PYPATHS = [
+        'addok.helpers.text.tokenize',
+        'addok.helpers.text.normalize',
+        'addok.helpers.text.flag_housenumber',
+        'addok.helpers.text.synonymize',
+    ]
+
+#### QUERY_PROCESSORS_PYPATHS (iterable of Python paths)
+Additional processors that are run only at query time. By default, only
+`check_query_length` is active, it depends on `QUERY_MAX_LENGTH` to avoid DoS.
+
+    QUERY_PROCESSORS_PYPATHS = (
+        'addok.helpers.text.check_query_length',
+    )
+
+#### RESULTS_COLLECTORS_PYPATHS (iterable of Python paths)
+Addok will try each of those in the given order for searching matching results.
+
+    RESULTS_COLLECTORS_PYPATHS = [
+        'addok.helpers.collectors.no_tokens_but_housenumbers_and_geohash',
+        'addok.helpers.collectors.no_available_tokens_abort',
+        'addok.helpers.collectors.only_commons',
+        'addok.helpers.collectors.bucket_with_meaningful',
+        'addok.helpers.collectors.reduce_with_other_commons',
+        'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',
+        'addok.helpers.collectors.extend_results_reducing_tokens',
+        'addok.helpers.collectors.extend_results_extrapoling_relations',
+    ]
+
+### SEARCH_RESULT_PROCESSORS_PYPATHS (iterable of Python paths)
+Post processing of each result found during search.
+
+    SEARCH_RESULT_PROCESSORS_PYPATHS = [
+        'addok.helpers.results.match_housenumber',
+        'addok.helpers.results.make_labels',
+        'addok.helpers.results.score_by_importance',
+        'addok.helpers.results.score_by_autocomplete_distance',
+        'addok.helpers.results.score_by_ngram_distance',
+        'addok.helpers.results.score_by_geo_distance',
+    ]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -69,7 +69,7 @@ QUERY_PROCESSORS_PYPATHS = [
     "addok_france.remove_leading_zeros",
 ]
 SEARCH_RESULT_PROCESSORS_PYPATHS = [
-    "addok_france.match_housenumber",
+    "addok.helpers.results.match_housenumber",
     "addok_france.make_labels",
     "addok.helpers.results.score_by_importance",
     "addok.helpers.results.score_by_autocomplete_distance",

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -4,14 +4,12 @@ from addok.helpers.text import Token
 
 def test_extract_manytomany_relations(factory, config):
     config.COMMON_THRESHOLD = 2
-    factory(name="rue de Paris", housenumbers={'513': {'lat': 1, 'lon': 2}})
+    factory(name="rue de Paris", city='Fecamp')
     factory(name="rue de la porte")
     factory(name="rue de dieppe", housenumbers={'506': {'lat': 1, 'lon': 2}})
-    tokens = [Token(s) for s in '513 rue de paris porte 506'.split()]
+    tokens = [Token(s) for s in 'rue de paris porte 506 fecamp'.split()]
     groups = _extract_manytomany_relations(tokens)
-    assert groups == [
-        set([Token('513'), Token('paris')])
-    ]
+    assert groups == [{Token('fecamp'), Token('paris')}]
 
 
 def test_extract_manytomany_relations_2(factory, config):

--- a/tests/test_index_utils.py
+++ b/tests/test_index_utils.py
@@ -58,18 +58,12 @@ def test_index_document():
     assert DB.exists('w|des')
     assert DB.exists('w|lilas')
     assert DB.exists('w|andresy')
-    assert DB.exists('w|1')  # Housenumber.
     assert DB.exists('p|rue')
     assert DB.exists('p|des')
     assert DB.exists('p|lilas')
     assert DB.exists('p|andresy')
     assert b'lilas' in DB.smembers('p|andresy')
     assert b'andresy' in DB.smembers('p|lilas')
-    assert DB.exists('p|1')
-    assert b'1' in DB.smembers('p|rue')
-    assert b'rue' in DB.smembers('p|1')
-    assert b'1' in DB.smembers('p|andresy')
-    assert b'andresy' in DB.smembers('p|1')
     assert DB.exists('g|u09dgm7')
     assert b'd|yyyy' in DB.smembers('g|u09dgm7')
     assert DB.exists('n|lil')
@@ -87,7 +81,7 @@ def test_index_document():
     assert b'd|yyyy' in DB.smembers('f|type|street')
     assert DB.exists('f|type|housenumber')
     assert b'd|yyyy' in DB.smembers('f|type|housenumber')
-    assert len(DB.keys()) == 19
+    assert len(DB.keys()) == 17
     assert len(ds._DB.keys()) == 1
 
 
@@ -147,30 +141,23 @@ def test_deindex_document_should_not_affect_other_docs():
     }
     index_document(DOC1)
     index_document(DOC2)
-    assert b'2' in DB.smembers('p|rue')
     deindex_document(DOC1['_id'])
     assert not ds._DB.exists('d|yyyy')
     assert b'd|yyyy' not in DB.zrange('w|rue', 0, -1)
     assert b'd|yyyy' not in DB.zrange('w|des', 0, -1)
     assert b'd|yyyy' not in DB.zrange('w|lilas', 0, -1)
-    assert b'd|yyyy' not in DB.zrange('w|1', 0, -1)
     assert DB.exists('g|u09dgm7')
     assert b'd|yyyy' not in DB.smembers('g|u09dgm7')
     assert DB.exists('w|des')
     assert DB.exists('w|lilas')
-    assert DB.exists('w|1')  # Housenumber.
-    assert b'andresy' not in DB.smembers('p|1')
-    assert b'2' not in DB.smembers('p|rue')
     assert DB.exists('p|rue')
     assert b'd|yyyy2' in DB.zrange('w|rue', 0, -1)
     assert b'd|yyyy2' in DB.zrange('w|des', 0, -1)
     assert b'd|yyyy2' in DB.zrange('w|lilas', 0, -1)
-    assert b'd|yyyy2' in DB.zrange('w|1', 0, -1)
     assert b'd|yyyy2' in DB.smembers('g|u09dgm7')
     assert b'd|yyyy2' in DB.smembers('g|u0g08g7')
     assert DB.exists('p|des')
     assert DB.exists('p|lilas')
-    assert DB.exists('p|1')
     assert not DB.exists('n|and')
     assert not DB.exists('n|andr')
     assert not DB.exists('n|andre')
@@ -185,7 +172,7 @@ def test_deindex_document_should_not_affect_other_docs():
     assert b'd|yyyy2' in DB.smembers('f|type|street')
     assert DB.exists('f|type|housenumber')
     assert b'd|yyyy2' in DB.smembers('f|type|housenumber')
-    assert len(DB.keys()) == 18
+    assert len(DB.keys()) == 16
     assert len(ds._DB.keys()) == 1
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+import pytest
+
 from addok.core import Result, search
 
 
@@ -97,6 +99,7 @@ def test_should_do_autocomplete_on_last_term(street):
 
 def test_synonyms_should_be_replaced(street, config):
     config.SYNONYMS = {'bd': 'boulevard'}
+    config.MIN_SCORE = 0
     street.update(name='boulevard des Fleurs')
     assert search('bd')
 
@@ -185,6 +188,20 @@ def test_should_autocomplete_if_only_commons_but_geohash(factory, config):
     factory(name="rue des aulnes")
     factory(name="rue descartes", lon=2.2, lat=48.1)
     results = search('rue des', autocomplete=True, lon=2.2, lat=48.1)
+    assert results[0].name == 'rue descartes'
+
+
+def test_should_autocomplete_if_only_housenumbers_but_geohash(factory, config):
+    config.COMMON_THRESHOLD = 3
+    config.BUCKET_MAX = 3
+    config.MIN_SCORE = 0.05
+    factory(name="rue des tilleuls", lon=2.256, lat=48.3254)
+    factory(name="rue des chênes", lon=2.256, lat=48.3254)
+    factory(name="rue des hètres", lon=2.256, lat=48.3254)
+    factory(name="rue des aulnes", lon=2.256, lat=48.3254)
+    factory(name="rue descartes", lon=2.256, lat=48.3254,
+            housenumbers={'11': {'lat': '48.3254', 'lon': '2.256'}})
+    results = search('11', autocomplete=True, lon=2.256, lat=48.3254)
     assert results[0].name == 'rue descartes'
 
 


### PR DESCRIPTION
Housenumbers take a lot of place in the index. Though they are not
a proper discriminating token: addok only match documents (streets)
and then try to match a housenumber in the document.

This is a bit radical, but may worth it: for 59+62 French deps data,
we reduce the Redis size from 640Mo to 240.

**Fully experimental!**