### PR TITLE
Remove /get/ API endpoint and _id from geojson properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+- breaking change: the key "id" is not required anymore in the loaded data and
+  as such has been removed from the geojson Feature root.
+
 ## 1.0.0-rc.4
 
 - housenumbers are not indexed anymore (to gain RAM), they are only matched in
@@ -37,6 +42,8 @@ and reindex everything.
   `index` and `deindex` methods
 - endpoints API changed
 - by default, documents are now stored in a separate Redis database
+- the key "id" is not required anymore in the loaded data and as such has been
+  removed from the geojson Feature root.
 
 ### Minor changes
 

--- a/addok/core.py
+++ b/addok/core.py
@@ -64,7 +64,7 @@ class Result:
         return value
 
     def __repr__(self):
-        return '<{} - {} ({})>'.format(str(self), self.id, self.score)
+        return '<{} - {} ({})>'.format(str(self), self._id, self.score)
 
     @property
     def keys(self):

--- a/addok/helpers/formatters.py
+++ b/addok/helpers/formatters.py
@@ -6,7 +6,7 @@ def geojson(result):
         properties["score"] = result.score
     for key in result.keys:
         val = getattr(result, key, None)
-        if val and key not in ['lat', 'lon']:
+        if val and key not in ['lat', 'lon', '_id']:
             properties[key] = val
     housenumber = getattr(result, 'housenumber', None)
     if housenumber:

--- a/addok/helpers/formatters.py
+++ b/addok/helpers/formatters.py
@@ -25,5 +25,4 @@ def geojson(result):
             "coordinates": [float(result.lon), float(result.lat)]
         },
         "properties": properties,
-        "id": result.id
     }

--- a/addok/http/base.py
+++ b/addok/http/base.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import falcon
 
 from addok.config import config
-from addok.core import Result, reverse, search
+from addok.core import reverse, search
 from addok.helpers.text import EntityTooLarge
 
 notfound_logger = None
@@ -112,18 +112,6 @@ class View:
         return lon, lat
 
 
-class Get(View):
-
-    def on_get(self, req, resp, doc_id, **kwargs):
-        try:
-            result = Result.from_id(doc_id)
-        except ValueError:
-            resp.content_type = 'text/html'
-            raise falcon.HTTPNotFound()
-        else:
-            self.json(req, resp, result.format())
-
-
 class Search(View):
 
     def on_get(self, req, resp, **kwargs):
@@ -166,7 +154,6 @@ class Reverse(View):
 
 
 def register_http_endpoint(api):
-    api.add_route('/get/{doc_id}', Get())
     api.add_route('/search', Search())
     api.add_route('/reverse', Reverse())
 

--- a/addok/shell.py
+++ b/addok/shell.py
@@ -229,7 +229,7 @@ class Cmd(cmd.Cmd):
         DB.delete(words)
         for id_, score in results:
             r = Result(id_)
-            print('{} {} {}'.format(white(r), blue(r.id), cyan(score)))
+            print('{} {} {}'.format(white(r), blue(r._id), cyan(score)))
         duration = round((time.time() - start) * 1000, 1)
         print(magenta("({} in {} ms)".format(len(results), duration)))
 
@@ -337,7 +337,7 @@ class Cmd(cmd.Cmd):
         if key:
             for id_ in DB.smembers(key):
                 r = Result(id_)
-                print('{} {}'.format(white(r), blue(r.id)))
+                print('{} {}'.format(white(r), blue(r._id)))
 
     def do_GET(self, _id):
         """Get document from index with its id.
@@ -389,7 +389,7 @@ class Cmd(cmd.Cmd):
         key = keys.token_key(indexed_string(word)[0])
         for _id, score in DB.zrevrange(key, 0, 20, withscores=True):
             result = Result(_id)
-            print(white(result), blue(score), blue(result.id))
+            print(white(result), blue(score), green(result._id))
 
     def do_REVERSE(self, latlon):
         """Do a reverse search. Args: lat lon.
@@ -397,7 +397,7 @@ class Cmd(cmd.Cmd):
         lat, lon = latlon.split()
         for r in reverse(float(lat), float(lon)):
             print('{} ({} | {} km | {})'.format(white(r), blue(r.score),
-                                                blue(r.distance), blue(r.id)))
+                                                blue(r.distance), blue(r._id)))
 
     def do_TOKENIZE(self, string):
         """Inspect how a string is tokenized before being indexed.

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,12 +94,3 @@ Parameters:
   parameters
 
 Same response format as the `/search/` enpoint.
-
-
-### /get/&lt;doc_id&gt;/
-
-Get a document from its id.
-
-#### Parameters
-
-- **doc_id**: the id of the document

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -115,26 +115,6 @@ def test_reverse_without_lat_or_lng_should_return_400(client, factory):
     assert resp.status_code == 400
 
 
-def test_get_endpoint(client, factory):
-    doc = factory(name='sentier de la côte', id='123')
-    resp = client.get('/get/{doc_id}'.format(doc_id=doc['_id']))
-    assert resp.json['properties']['id'] == '123'
-
-
-def test_get_endpoint_with_invalid_id(client):
-    resp = client.get('/get/123')
-    assert resp.status_code == 404
-    assert resp.body == ''
-    assert resp.headers['content-type'] == 'text/html'
-
-
-def test_get_should_have_cors_headers(client, factory):
-    factory(name='sentier de la côte', id='123')
-    resp = client.get('/get/123')
-    assert resp.headers['Access-Control-Allow-Origin'] == '*'
-    assert resp.headers['Access-Control-Allow-Headers'] == 'X-Requested-With'
-
-
 def test_view_should_expose_config(config):
     config.NEW_PROPERTY = "ok"
     assert View.config.NEW_PROPERTY == "ok"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,3 @@
-import pytest
-
 from addok.core import Result, search
 
 


### PR DESCRIPTION
I let `Result.from_id()` even if not anymore in use, thoughts?