### PR TITLE
Add optional Redis authentication

### DIFF
--- a/addok/ds.py
+++ b/addok/ds.py
@@ -47,7 +47,12 @@ def on_load():
     if config.DOCUMENT_STORE == RedisStore:
         params = config.REDIS.copy()
         params.update(config.REDIS.get('documents', {}))
-        _DB.connect(host=params['host'], port=params['port'], db=params['db'])
+        _DB.connect(
+            host=params['host'],
+            port=params['port'],
+            db=params['db'],
+            password=params.get('password')
+        )
 
 
 def store_documents(docs):


### PR DESCRIPTION
Due to  #316, I've done a PR
The changed line is the following
```
_DB.connect(host=params['host'], port=params['port'], db=params['db'])
```
I've replace it with

```
_DB.connect(
    host=params['host'],
    port=params['port'],
    db=params['db'],
    password=params.get('password')
)
```


`_DB` reference RedisProxy https://github.com/addok/addok/blob/master/addok/ds.py#L39
It comes from https://github.com/addok/addok/blob/master/addok/db.py#L10
Via `connect` function, it calls `redis.StrictRedis` (https://github.com/addok/addok/blob/master/addok/db.py#L15)

This function expects `password=None` if no password otherwise `password=your_password`as stated in the docs https://redis-py.readthedocs.io/en/latest/#redis.StrictRedis
My solution is to say, set the password to `None`, otherwise to the content of REDIS password block configuration (done through a copy and referenced as `params`)
