### PR TITLE
Update result with housenumber fields in reverse

### DIFF
--- a/addok/helpers/results.py
+++ b/addok/helpers/results.py
@@ -109,7 +109,6 @@ def load_closer(helper, result):
     candidates.sort(key=sort)
     closer = candidates[0]
     if closer['raw']:  # Means a housenumber is closer than street center.
-        result.housenumber = closer['raw']
-        result.lat = closer['lat']
-        result.lon = closer['lon']
+        result.housenumber = closer.pop('raw')
         result.type = 'housenumber'
+        result.update(closer)

--- a/tests/test_reverse.py
+++ b/tests/test_reverse.py
@@ -8,10 +8,13 @@ def test_reverse_return_closer_point(factory):
 
 
 def test_reverse_return_housenumber(factory):
-    factory(housenumbers={'24': {'lat': 48.234545, 'lon': 5.235445}})
+    factory(housenumbers={'24': {'lat': 48.234545, 'lon': 5.235445,
+                                 'key': 'value'}})
     results = reverse(lat=48.234545, lon=5.235445)
     assert results[0].housenumber == '24'
     assert results[0].type == 'housenumber'
+    assert results[0].key == 'value'
+    assert not results[0].raw
 
 
 def test_reverse_can_be_limited(factory):


### PR DESCRIPTION
fix #374

Allow to return extra housenumber fields, this is done for normal search, but was missing for reverse.