### PR TITLE
More reduce tokens (WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 - Faster new scoring algorithm (#431)
 - Upgraded Falcon to 1.4.1
+- `autocomplete` and `fuzzy` are not adding any more their collectors automagically,
+  instead they are now hard coded in the default config; if you haven't changed
+  `RESULTS_COLLECTORS_PYPATHS` in your local config this should not impact you,
+  otherwise, see "Updating" below.
+
+### Updating to dev
+
+If you have changed `RESULTS_COLLECTORS_PYPATHS` in your local config file, make
+sure to add manually `fuzzy` and `autocomplete` ones. Check the
+[config doc](config.md) for an example.
+
 
 ## 1.0.2
 

--- a/addok/autocomplete.py
+++ b/addok/autocomplete.py
@@ -125,19 +125,6 @@ def register_command(subparsers):
     parser.set_defaults(func=create_edge_ngrams)
 
 
-def configure(config):
-    config.RESULTS_COLLECTORS_PYPATHS.insert(0, only_commons_but_geohash_try_autocomplete_collector)  # noqa
-    target = 'addok.helpers.collectors.only_commons'
-    if target in config.RESULTS_COLLECTORS_PYPATHS:
-        idx = config.RESULTS_COLLECTORS_PYPATHS.index(target)
-        config.RESULTS_COLLECTORS_PYPATHS.insert(idx + 1, only_commons_try_autocomplete_collector)  # noqa
-        config.RESULTS_COLLECTORS_PYPATHS.insert(idx + 1, no_meaningful_but_common_try_autocomplete_collector)  # noqa
-    target = 'addok.helpers.collectors.extend_results_reducing_tokens'
-    if target in config.RESULTS_COLLECTORS_PYPATHS:
-        idx = config.RESULTS_COLLECTORS_PYPATHS.index(target)
-        config.RESULTS_COLLECTORS_PYPATHS.insert(idx, autocomplete_meaningful_collector)  # noqa
-
-
 def do_AUTOCOMPLETE(cmd, s):
     """Shows autocomplete results for a given token."""
     s = list(preprocess_query(s))[0]

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -73,8 +73,8 @@ RESULTS_COLLECTORS_PYPATHS = [
     'addok.helpers.collectors.bucket_with_meaningful',
     'addok.helpers.collectors.reduce_with_other_commons',
     'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',  # noqa
-    'addok.helpers.collectors.extend_results_reducing_tokens',
     'addok.helpers.collectors.extend_results_extrapoling_relations',
+    'addok.helpers.collectors.extend_results_reducing_tokens',
 ]
 SEARCH_RESULT_PROCESSORS_PYPATHS = [
     'addok.helpers.results.match_housenumber',

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -73,6 +73,8 @@ RESULTS_COLLECTORS_PYPATHS = [
     'addok.helpers.collectors.bucket_with_meaningful',
     'addok.helpers.collectors.reduce_with_other_commons',
     'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',  # noqa
+    'addok.fuzzy.fuzzy_collector',
+    'addok.autocomplete.autocomplete_meaningful_collector',
     'addok.helpers.collectors.extend_results_extrapoling_relations',
     'addok.helpers.collectors.extend_results_reducing_tokens',
 ]

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -67,9 +67,12 @@ BATCH_CHUNK_SIZE = 1000
 # let one process free for Redis by default.
 BATCH_WORKERS = max(os.cpu_count() - 1, 1)
 RESULTS_COLLECTORS_PYPATHS = [
+    'addok.autocomplete.only_commons_but_geohash_try_autocomplete_collector',
     'addok.helpers.collectors.no_tokens_but_housenumbers_and_geohash',
     'addok.helpers.collectors.no_available_tokens_abort',
     'addok.helpers.collectors.only_commons',
+    'addok.autocomplete.no_meaningful_but_common_try_autocomplete_collector',
+    'addok.autocomplete.only_commons_try_autocomplete_collector',
     'addok.helpers.collectors.bucket_with_meaningful',
     'addok.helpers.collectors.reduce_with_other_commons',
     'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',  # noqa

--- a/addok/fuzzy.py
+++ b/addok/fuzzy.py
@@ -97,14 +97,6 @@ def try_fuzzy(helper, tokens, include_common=True):
                     helper.add_to_bucket(keys + [key])
 
 
-def configure(config):
-    target = 'addok.helpers.collectors.extend_results_reducing_tokens'
-    if target in config.RESULTS_COLLECTORS_PYPATHS:
-        idx = config.RESULTS_COLLECTORS_PYPATHS.index(target)
-        config.RESULTS_COLLECTORS_PYPATHS.insert(
-            idx, 'addok.fuzzy.fuzzy_collector')
-
-
 def do_fuzzy(self, word):
     """Compute fuzzy extensions of word.
     FUZZY lilas"""

--- a/addok/helpers/collectors.py
+++ b/addok/helpers/collectors.py
@@ -117,8 +117,8 @@ def extend_results_reducing_tokens(helper):
             if helper.bucket_overflow:
                 break
 
-        if helper.bucket_empty and len(helper.meaningful)>2:
-            helper.debug("Bucket still empty, let's remove 2 meaningful tokens.")
+        if helper.bucket_empty and len(helper.meaningful) > 3:
+            helper.debug("Bucket still empty, remove 2 meaningful tokens.")
             for token, token2 in product(helper.meaningful, helper.meaningful):
                 if token != token2:
                     keys = helper.keys[:]
@@ -127,6 +127,7 @@ def extend_results_reducing_tokens(helper):
                     helper.add_to_bucket(keys)
                     if helper.bucket_overflow:
                         break
+
 
 def extend_results_extrapoling_relations(helper):
     """Try to extract the bigger group of interlinked tokens.

--- a/addok/helpers/collectors.py
+++ b/addok/helpers/collectors.py
@@ -5,6 +5,7 @@ from addok.db import DB
 from addok.helpers import scripts
 from addok.pairs import pair_key
 
+from itertools import product
 
 def no_tokens_but_housenumbers_and_geohash(helper):
     if not helper.tokens and helper.housenumbers and helper.geohash_key:
@@ -102,7 +103,7 @@ def extend_results_reducing_tokens(helper):
     # Only if bucket is empty or we have margin on should_match_threshold.
     if (helper.bucket_empty
             or len(helper.meaningful) - 1 > helper.should_match_threshold):
-        helper.debug('Bucket dry. Trying to remove some tokens.')
+        helper.debug('Bucket dry. Trying to remove 1 meaningful token.')
 
         def sorter(t):
             # First numbers, then by frequency
@@ -116,6 +117,16 @@ def extend_results_reducing_tokens(helper):
             if helper.bucket_overflow:
                 break
 
+        if helper.bucket_empty and len(helper.meaningful)>2:
+            helper.debug("Bucket still empty, let's remove 2 meaningful tokens.")
+            for token, token2 in product(helper.meaningful, helper.meaningful):
+                if token != token2:
+                    keys = helper.keys[:]
+                    keys.remove(token.db_key)
+                    keys.remove(token2.db_key)
+                    helper.add_to_bucket(keys)
+                    if helper.bucket_overflow:
+                        break
 
 def extend_results_extrapoling_relations(helper):
     """Try to extract the bigger group of interlinked tokens.

--- a/addok/helpers/formatters.py
+++ b/addok/helpers/formatters.py
@@ -14,8 +14,6 @@ def geojson(result):
             properties[result._doc['type']] = properties.get('name')
         properties['name'] = '{} {}'.format(housenumber,
                                             properties.get('name'))
-    else:
-        properties['street'] = properties.get('name')
     try:
         properties['distance'] = int(result.distance)
     except ValueError:

--- a/addok/helpers/formatters.py
+++ b/addok/helpers/formatters.py
@@ -14,6 +14,8 @@ def geojson(result):
             properties[result._doc['type']] = properties.get('name')
         properties['name'] = '{} {}'.format(housenumber,
                                             properties.get('name'))
+    else:
+        properties['street'] = properties.get('name')
     try:
         properties['distance'] = int(result.distance)
     except ValueError:

--- a/docs/config.md
+++ b/docs/config.md
@@ -302,14 +302,19 @@ Additional processors that are run only at query time. By default, only
 Addok will try each of those in the given order for searching matching results.
 
     RESULTS_COLLECTORS_PYPATHS = [
+        'addok.autocomplete.only_commons_but_geohash_try_autocomplete_collector',
         'addok.helpers.collectors.no_tokens_but_housenumbers_and_geohash',
         'addok.helpers.collectors.no_available_tokens_abort',
         'addok.helpers.collectors.only_commons',
+        'addok.autocomplete.no_meaningful_but_common_try_autocomplete_collector',
+        'addok.autocomplete.only_commons_try_autocomplete_collector',
         'addok.helpers.collectors.bucket_with_meaningful',
         'addok.helpers.collectors.reduce_with_other_commons',
-        'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',
-        'addok.helpers.collectors.extend_results_reducing_tokens',
+        'addok.helpers.collectors.ensure_geohash_results_are_included_if_center_is_given',  # noqa
+        'addok.fuzzy.fuzzy_collector',
+        'addok.autocomplete.autocomplete_meaningful_collector',
         'addok.helpers.collectors.extend_results_extrapoling_relations',
+        'addok.helpers.collectors.extend_results_reducing_tokens',
     ]
 
 ### SEARCH_RESULT_PROCESSORS_PYPATHS (iterable of Python paths)


### PR DESCRIPTION
extend_results_reducing_tokens only tries to remove one meaningful token

This PR add another step by removing 2 meaningful tokens when the bucket is still empty.

One example: **quai jules verne st cyprie plage**

Before:

```
> EXPLAIN quai jules verne st cyprie plage
[7.951] Taken tokens: [<Token sipri>, <Token vern>, <Token kai>, <Token plaj>, <Token jul>]
[7.969] Common tokens: [<Token sain>]
[7.973] Housenumbers token: []
[7.976] Not found tokens: []
[7.981] Filters: []
[7.989] ** ONLY_COMMONS_BUT_GEOHASH_TRY_AUTOCOMPLETE_COLLECTOR **
[7.996] ** NO_TOKENS_BUT_HOUSENUMBERS_AND_GEOHASH **
[8.000] ** NO_AVAILABLE_TOKENS_ABORT **
[8.004] ** ONLY_COMMONS **
[8.011] ** NO_MEANINGFUL_BUT_COMMON_TRY_AUTOCOMPLETE_COLLECTOR **
[8.015] ** ONLY_COMMONS_TRY_AUTOCOMPLETE_COLLECTOR **
[8.020] ** BUCKET_WITH_MEANINGFUL **
[8.033] New bucket with keys ['w|sipri', 'w|vern', 'w|kai', 'w|plaj', 'w|jul'] and limit 10
[8.240] 0 ids in bucket so far
[8.250] ** REDUCE_WITH_OTHER_COMMONS **
[8.260] ** ENSURE_GEOHASH_RESULTS_ARE_INCLUDED_IF_CENTER_IS_GIVEN **
[8.266] ** FUZZY_COLLECTOR **
[8.282] Fuzzy on. Trying with [<Token sipri>, <Token vern>, <Token kai>, <Token plaj>, <Token jul>].
[8.298] Going fuzzy with sipri and ['w|vern', 'w|kai', 'w|plaj', 'w|jul', 'w|sain']
[9.983] Going fuzzy with vern and ['w|sipri', 'w|kai', 'w|plaj', 'w|jul', 'w|sain']
[11.38] Going fuzzy with plaj and ['w|sipri', 'w|vern', 'w|kai', 'w|jul', 'w|sain']
[12.80] Going fuzzy with kai and ['w|sipri', 'w|vern', 'w|plaj', 'w|jul', 'w|sain']
[14.02] Going fuzzy with jul and ['w|sipri', 'w|vern', 'w|kai', 'w|plaj', 'w|sain']
[15.09] Fuzzy on. Trying with [<Token sipri>, <Token vern>, <Token plaj>, <Token kai>, <Token jul>].
[15.11] Going fuzzy with sipri and ['w|vern', 'w|kai', 'w|plaj', 'w|jul']
[16.60] Going fuzzy with vern and ['w|sipri', 'w|kai', 'w|plaj', 'w|jul']
[17.94] Going fuzzy with plaj and ['w|sipri', 'w|vern', 'w|kai', 'w|jul']
[19.17] Going fuzzy with kai and ['w|sipri', 'w|vern', 'w|plaj', 'w|jul']
[20.18] Going fuzzy with jul and ['w|sipri', 'w|vern', 'w|kai', 'w|plaj']
[21.19] ** AUTOCOMPLETE_MEANINGFUL_COLLECTOR **
[21.20] Autocompleting plaj
[21.30] Found tokens to autocomplete set()
[21.30] ** EXTEND_RESULTS_REDUCING_TOKENS **
[21.31] Bucket dry. Trying to remove some tokens.
[21.33] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|kai', 'w|plaj']
[21.46] 0 ids in bucket so far
[21.48] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|kai', 'w|jul']
[21.59] 0 ids in bucket so far
[21.60] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|plaj', 'w|jul']
[21.76] 0 ids in bucket so far
[21.77] Adding to bucket with keys ['w|sipri', 'w|kai', 'w|plaj', 'w|jul']
[21.93] 0 ids in bucket so far
[21.94] Adding to bucket with keys ['w|vern', 'w|kai', 'w|plaj', 'w|jul']
[22.66] 0 ids in bucket so far
[22.67] ** EXTEND_RESULTS_EXTRAPOLING_RELATIONS **
[24.18] Adding to bucket with keys ['w|plaj', 'w|jul', 'w|vern', 'w|kai']
[24.49] 0 ids in bucket so far
[24.50] No relation extrapolated.
[24.51] Computing results
[24.52] Done computing results
24.5 ms — 1 run(s) — 0 results
```

After:

```
> EXPLAIN quai jules verne st cyprie plage
[8.116] Taken tokens: [<Token sipri>, <Token vern>, <Token kai>, <Token plaj>, <Token jul>]
[8.133] Common tokens: [<Token sain>]
[8.137] Housenumbers token: []
[8.140] Not found tokens: []
[8.145] Filters: []
[8.153] ** ONLY_COMMONS_BUT_GEOHASH_TRY_AUTOCOMPLETE_COLLECTOR **
[8.159] ** NO_TOKENS_BUT_HOUSENUMBERS_AND_GEOHASH **
[8.163] ** NO_AVAILABLE_TOKENS_ABORT **
[8.167] ** ONLY_COMMONS **
[8.173] ** NO_MEANINGFUL_BUT_COMMON_TRY_AUTOCOMPLETE_COLLECTOR **
[8.177] ** ONLY_COMMONS_TRY_AUTOCOMPLETE_COLLECTOR **
[8.182] ** BUCKET_WITH_MEANINGFUL **
[8.195] New bucket with keys ['w|sipri', 'w|vern', 'w|kai', 'w|plaj', 'w|jul'] and limit 10
[8.416] 0 ids in bucket so far
[8.426] ** REDUCE_WITH_OTHER_COMMONS **
[8.436] ** ENSURE_GEOHASH_RESULTS_ARE_INCLUDED_IF_CENTER_IS_GIVEN **
[8.442] ** FUZZY_COLLECTOR **
[8.465] Fuzzy on. Trying with [<Token sipri>, <Token vern>, <Token kai>, <Token plaj>, <Token jul>].
[8.482] Going fuzzy with sipri and ['w|vern', 'w|kai', 'w|plaj', 'w|jul', 'w|sain']
[10.19] Going fuzzy with vern and ['w|sipri', 'w|kai', 'w|plaj', 'w|jul', 'w|sain']
[11.86] Going fuzzy with plaj and ['w|sipri', 'w|vern', 'w|kai', 'w|jul', 'w|sain']
[13.44] Going fuzzy with kai and ['w|sipri', 'w|vern', 'w|plaj', 'w|jul', 'w|sain']
[14.73] Going fuzzy with jul and ['w|sipri', 'w|vern', 'w|kai', 'w|plaj', 'w|sain']
[16.07] Fuzzy on. Trying with [<Token sipri>, <Token vern>, <Token plaj>, <Token kai>, <Token jul>].
[16.09] Going fuzzy with sipri and ['w|vern', 'w|kai', 'w|plaj', 'w|jul']
[17.74] Going fuzzy with vern and ['w|sipri', 'w|kai', 'w|plaj', 'w|jul']
[19.26] Going fuzzy with plaj and ['w|sipri', 'w|vern', 'w|kai', 'w|jul']
[20.80] Going fuzzy with kai and ['w|sipri', 'w|vern', 'w|plaj', 'w|jul']
[22.14] Going fuzzy with jul and ['w|sipri', 'w|vern', 'w|kai', 'w|plaj']
[23.48] ** AUTOCOMPLETE_MEANINGFUL_COLLECTOR **
[23.50] Autocompleting plaj
[23.69] Found tokens to autocomplete set()
[23.70] ** EXTEND_RESULTS_REDUCING_TOKENS **
[23.71] Bucket dry. Trying to remove 1 meaningful token.
[23.74] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|kai', 'w|plaj']
[23.98] 0 ids in bucket so far
[24.00] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|kai', 'w|jul']
[24.21] 0 ids in bucket so far
[24.23] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|plaj', 'w|jul']
[24.45] 0 ids in bucket so far
[24.47] Adding to bucket with keys ['w|sipri', 'w|kai', 'w|plaj', 'w|jul']
[24.68] 0 ids in bucket so far
[24.70] Adding to bucket with keys ['w|vern', 'w|kai', 'w|plaj', 'w|jul']
[25.47] 0 ids in bucket so far
[25.48] Bucket still empty, let's remove 2 meaningful tokens.
[25.50] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|kai']
[25.72] 0 ids in bucket so far
[25.74] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|plaj']
[25.99] 0 ids in bucket so far
[26.01] Adding to bucket with keys ['w|sipri', 'w|kai', 'w|plaj']
[26.23] 0 ids in bucket so far
[26.25] Adding to bucket with keys ['w|vern', 'w|kai', 'w|plaj']
[26.67] 0 ids in bucket so far
[26.69] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|kai']
[26.90] 0 ids in bucket so far
[26.92] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|jul']
[27.14] 0 ids in bucket so far
[27.16] Adding to bucket with keys ['w|sipri', 'w|kai', 'w|jul']
[27.37] 0 ids in bucket so far
[27.39] Adding to bucket with keys ['w|vern', 'w|kai', 'w|jul']
[27.83] 2 ids in bucket so far
[27.85] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|plaj']
[28.06] 2 ids in bucket so far
[28.08] Adding to bucket with keys ['w|sipri', 'w|vern', 'w|jul']
[28.28] 2 ids in bucket so far
[28.30] Adding to bucket with keys ['w|sipri', 'w|plaj', 'w|jul']
[28.47] 2 ids in bucket so far
[28.48] Adding to bucket with keys ['w|vern', 'w|plaj', 'w|jul']
[28.99] 3 ids in bucket so far
[29.00] Adding to bucket with keys ['w|sipri', 'w|kai', 'w|plaj']
[29.16] 3 ids in bucket so far
[29.17] Adding to bucket with keys ['w|sipri', 'w|kai', 'w|jul']
[29.33] 3 ids in bucket so far
[29.34] Adding to bucket with keys ['w|sipri', 'w|plaj', 'w|jul']
[29.52] 3 ids in bucket so far
[29.54] Adding to bucket with keys ['w|kai', 'w|plaj', 'w|jul']
[30.54] 3 ids in bucket so far
[30.56] Adding to bucket with keys ['w|vern', 'w|kai', 'w|plaj']
[30.93] 3 ids in bucket so far
[30.94] Adding to bucket with keys ['w|vern', 'w|kai', 'w|jul']
[31.37] 3 ids in bucket so far
[31.39] Adding to bucket with keys ['w|vern', 'w|plaj', 'w|jul']
[31.81] 3 ids in bucket so far
[31.82] Adding to bucket with keys ['w|kai', 'w|plaj', 'w|jul']
[32.47] 3 ids in bucket so far
[32.49] ** EXTEND_RESULTS_EXTRAPOLING_RELATIONS **
[34.57] Adding to bucket with keys ['w|jul', 'w|vern', 'w|kai', 'w|plaj']
[34.87] 3 ids in bucket so far
[34.88] No relation extrapolated.
[34.89] Computing results
[34.90] Done getting results data
[36.83] Done computing results
Quai Jules Verne 66750 Saint-Cyprien (6v9Yz | str_distance: 0.5143/1.0, importance: 0.0076/0.1)
Quai Jules Verne 80230 Saint-Valery-sur-Somme (JxVMo | str_distance: 0.4355/1.0, importance: 0.0128/0.1)
Rue Jules Verne 17340 Châtelaillon-Plage (JyYv2 | str_distance: 0.36/1.0, importance: 0.004/0.1)
36.9 ms — 1 run(s) — 3 results

```
