### PR TITLE
Add a slow query log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   instead they are now hard coded in the default config; if you haven't changed
   `RESULTS_COLLECTORS_PYPATHS` in your local config this should not impact you,
   otherwise, see "Updating" below.
+- Added a slow queries logger (see [config](config.md#slow_queries-integer) for usage)
 
 ### Updating to dev
 

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -145,5 +145,6 @@ LOG_DIR = os.environ.get("ADDOK_LOG_DIR", Path(__file__).parent.parent.parent)
 
 LOG_QUERIES = False
 LOG_NOT_FOUND = False
+SLOW_QUERIES = False  # False or time in ms to consider query as slow
 
 INDEX_EDGE_NGRAMS = True

--- a/addok/helpers/formatters.py
+++ b/addok/helpers/formatters.py
@@ -14,8 +14,6 @@ def geojson(result):
             properties[result._doc['type']] = properties.get('name')
         properties['name'] = '{} {}'.format(housenumber,
                                             properties.get('name'))
-    else:
-        properties['street'] = properties.get('name')
     try:
         properties['distance'] = int(result.distance)
     except ValueError:

--- a/addok/http/base.py
+++ b/addok/http/base.py
@@ -158,13 +158,13 @@ class Search(View):
         if lon and lat:
             center = (lon, lat)
         filters = self.match_filters(req)
-        timer = time.clock()
+        timer = time.perf_counter()
         try:
             results = search(query, limit=limit, autocomplete=autocomplete,
                              lat=lat, lon=lon, **filters)
         except EntityTooLarge as e:
             raise falcon.HTTPRequestEntityTooLarge(str(e))
-        timer = int((time.clock() - timer)*1000)
+        timer = int((time.perf_counter()-timer)*1000)
         if not results:
             log_notfound(query)
         log_query(query, results)

--- a/addok/http/base.py
+++ b/addok/http/base.py
@@ -15,46 +15,33 @@ query_logger = None
 slow_query_logger = None
 
 
+def get_logger(name):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    filename = Path(config.LOG_DIR).joinpath('{}.log'.format(name))
+    try:
+        handler = logging.handlers.TimedRotatingFileHandler(
+                                            str(filename), when='midnight')
+    except FileNotFoundError:
+        print('Unable to write to {}'.format(filename))
+    else:
+        logger.addHandler(handler)
+    return logger
+
+
 @config.on_load
 def on_load():
     if config.LOG_NOT_FOUND:
         global notfound_logger
-        notfound_logger = logging.getLogger('notfound')
-        notfound_logger.setLevel(logging.DEBUG)
-        filename = Path(config.LOG_DIR).joinpath('notfound.log')
-        try:
-            handler = logging.handlers.TimedRotatingFileHandler(
-                                                str(filename), when='midnight')
-        except FileNotFoundError:
-            print('Unable to write to {}'.format(filename))
-        else:
-            notfound_logger.addHandler(handler)
+        notfound_logger = get_logger('notfound')
 
     if config.LOG_QUERIES:
         global query_logger
-        query_logger = logging.getLogger('queries')
-        query_logger.setLevel(logging.DEBUG)
-        filename = Path(config.LOG_DIR).joinpath('queries.log')
-        try:
-            handler = logging.handlers.TimedRotatingFileHandler(
-                                                str(filename), when='midnight')
-        except FileNotFoundError:
-            print('Unable to write to {}'.format(filename))
-        else:
-            query_logger.addHandler(handler)
+        query_logger = get_logger('queries')
 
     if config.SLOW_QUERIES:
         global slow_query_logger
-        slow_query_logger = logging.getLogger('slow_queries')
-        slow_query_logger.setLevel(logging.DEBUG)
-        filename = Path(config.LOG_DIR).joinpath('slow_queries.log')
-        try:
-            handler = logging.handlers.TimedRotatingFileHandler(
-                                                str(filename), when='midnight')
-        except FileNotFoundError:
-            print('Unable to write to {}'.format(filename))
-        else:
-            slow_query_logger.addHandler(handler)
+        slow_query_logger = get_logger('slow_queries')
 
 
 def log_notfound(query):

--- a/addok/http/base.py
+++ b/addok/http/base.py
@@ -14,6 +14,7 @@ notfound_logger = None
 query_logger = None
 slow_query_logger = None
 
+
 @config.on_load
 def on_load():
     if config.LOG_NOT_FOUND:
@@ -42,7 +43,7 @@ def on_load():
         else:
             query_logger.addHandler(handler)
 
-    if config.LOG_SLOW_QUERIES:
+    if config.SLOW_QUERIES:
         global slow_query_logger
         slow_query_logger = logging.getLogger('slow_queries')
         slow_query_logger.setLevel(logging.DEBUG)
@@ -54,6 +55,7 @@ def on_load():
             print('Unable to write to {}'.format(filename))
         else:
             slow_query_logger.addHandler(handler)
+
 
 def log_notfound(query):
     if config.LOG_NOT_FOUND:
@@ -70,8 +72,9 @@ def log_query(query, results):
             score = '-'
         query_logger.debug('\t'.join([query, result, score]))
 
+
 def log_slow_query(query, results, timer):
-    if config.LOG_SLOW_QUERIES:
+    if config.SLOW_QUERIES:
         if results:
             result = str(results[0])
             score = str(round(results[0].score, 2))
@@ -80,7 +83,8 @@ def log_slow_query(query, results, timer):
             result = '-'
             score = '-'
             id_ = '-'
-        slow_query_logger.debug('\t'.join([str(timer), query, id_, result, score]))
+        slow_query_logger.debug('\t'.join([str(timer),
+                                           query, id_, result, score]))
 
 
 class CorsMiddleware:
@@ -164,7 +168,7 @@ class Search(View):
         if not results:
             log_notfound(query)
         log_query(query, results)
-        if config.SLOW_QUERY and timer > config.SLOW_QUERY:
+        if config.SLOW_QUERIES and timer > config.SLOW_QUERIES:
             log_slow_query(query, results, timer)
         self.to_geojson(req, resp, results, query=query, filters=filters,
                         center=center, limit=limit)

--- a/docs/config.md
+++ b/docs/config.md
@@ -168,6 +168,12 @@ processed.
 
     QUERY_MAX_LENGTH = 200
 
+#### SLOW_QUERIES (integer)
+Define the time (in ms) to log a slow query.
+
+    SLOW_QUERIES = False  # Inactive
+    SLOW_QUERIES = 500  # Will log every query longer than 500 ms
+
 #### SYNONYMS_PATH (path)
 Path to the synonym file. Synonyms file are in the format `av, ave => avenue`.
 


### PR DESCRIPTION
Add a slow query log...

New config entry:

SLOW_QUERIES = time limit (in ms) to consider a query as slow or False

Format (tab separator):
- time
- query
- id
- result
- score
