### PR TITLE
Fix license inconsistency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 DINSIC/Etalab
+Copyright (c) 2020 DINUM/Etalab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,4 @@ The code is published via [Github](https://github.com/addok/addok/).
 
 ## Licence
 
-Addok is released under the WTFPL Licence.
+Addok is released under the MIT Licence.

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     url=__homepage__,
     author=__author__,
     author_email=__contact__,
-    license='WTFPL',
+    license='MIT',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
The correct license is MIT, according to #534 and https://github.com/addok/addok/commit/f4899654cf8da16701b01343fb564380a76b0019

Close #626 
Fix #620 