### PR TITLE
Allow picking BATCH_WORKERS var from environment

### DIFF
--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -65,7 +65,7 @@ BATCH_FILE_LOADER_PYPATH = 'addok.helpers.load_file'
 BATCH_CHUNK_SIZE = 1000
 # During imports, workers are consuming RAM;
 # let one process free for Redis by default.
-BATCH_WORKERS = max(os.cpu_count() - 1, 1)
+BATCH_WORKERS = int(os.environ.get('BATCH_WORKERS')) if os.environ.get('BATCH_WORKERS') else max(os.cpu_count() - 1, 1)
 RESULTS_COLLECTORS_PYPATHS = [
     'addok.helpers.collectors.no_tokens_but_housenumbers_and_geohash',
     'addok.helpers.collectors.no_available_tokens_abort',


### PR DESCRIPTION
When you prepare your addok dataset (`addok batch`) it could be more practical to define `BATCH_WORKERS` from environment than from config file.