### PR TITLE
Proposal to load whatever config variable from env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ testall:
 	cd ../addok-fr && py.test --quiet
 	cd ../addok-csv && py.test --quiet
 	cd ../addok-sqlite-store && py.test --quiet
+clean:
+	rm -rf dist/* build/*
 dist:
 	python setup.py sdist bdist_wheel
 upload:

--- a/addok/config/__init__.py
+++ b/addok/config/__init__.py
@@ -41,6 +41,7 @@ class Config(dict):
             hooks.load()  # pragma: no cover
         hooks.preconfigure(self)
         self.load_local()
+        self.load_from_env()
         hooks.configure(self)
         self.resolve()
         self.post_process()
@@ -90,6 +91,16 @@ class Config(dict):
         else:
             print("Loaded local config from", path)
             self.extend_from_object(d)
+
+    def load_from_env(self):
+        for key, value in self.items():
+            if key.isupper():
+                env_key = "ADDOK_" + key
+                typ = type(value)
+                if typ in (list, tuple, set):
+                    real_type, typ = typ, lambda x: real_type(x.split(","))
+                if env_key in os.environ:
+                    self[key] = typ(os.environ[env_key])
 
     def __getattr__(self, key):
         return self.get(key)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -56,3 +56,13 @@ def test_config_load_exit_if_local_file_is_invalid():
         config.load()
         assert "Unable to import" in err
     os.environ["ADDOK_CONFIG_MODULE"] = ""
+
+
+def test_config_on_load_consume_env_vars():
+    from addok.config import Config
+
+    os.environ["ADDOK_BATCH_WORKERS"] = "13"
+    config = Config()
+
+    config.load()
+    assert config.BATCH_WORKERS == 13


### PR DESCRIPTION
eg. to override BATCH_WORKERS when running import:

    ADDOK_BATCH_WORKERS=12 addok batch

We may or not want to use the prefix `ADDOK_` to prevent name clashes.

cc @jdesboeufs alternative proposal of #735 