### PR TITLE
Update gnureadline (8.1.2) to support arm64 architecture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open('requirements.txt', encoding='utf-8') as reqs:
     install_requires = [l for l in reqs.read().split('\n') if is_pkg(l)]
 
 if sys.platform == 'darwin':
-    install_requires.append('gnureadline==6.3.3')
+    install_requires.append('gnureadline==8.1.2')
 
 try:
     from Cython.Distutils import build_ext


### PR DESCRIPTION
With this PR we are able to build addok on Apple Silicon (and Raspberry Pi).

Initially I was considering to drop `gnureadline` since most of Mac OS X environments are already built with `gnureadline`, but we should have to write a compatibility warning for `System Python` and MacPorts-based Python…

As Mac are never production environments, we can continue to pollute the dependency tree…