### PR TITLE
Replace legacy scoring algorithm for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Better ordering of candidates in case of autocomplete (#494)
 - By default, use more common chars when building fuzzy variants
 - Added python >= 3.8 compat
+- Restore legacy scoring algorithm (#746): the new experimental scoring must be
+  activated manually, replacing `addok.helpers.results.score_by_ngram_distance` with
+  `addok.helpers.results.score_by_str_distance` in `SEARCH_RESULT_PROCESSORS_PYPATHS`
 
 
 ## 1.1.0-rc1

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -86,7 +86,7 @@ SEARCH_RESULT_PROCESSORS_PYPATHS = [
     "addok.helpers.results.make_labels",
     "addok.helpers.results.score_by_importance",
     "addok.helpers.results.score_by_autocomplete_distance",
-    "addok.helpers.results.score_by_str_distance",
+    "addok.helpers.results.score_by_ngram_distance",
     "addok.helpers.results.score_by_geo_distance",
     "addok.helpers.results.adjust_scores",
 ]

--- a/addok/helpers/results.py
+++ b/addok/helpers/results.py
@@ -1,6 +1,13 @@
 from addok.config import config
 from addok.helpers import haversine_distance, km_to_score
-from addok.helpers.text import ascii, compare_str, contains, equals, startswith
+from addok.helpers.text import (
+    ascii,
+    compare_ngrams,
+    compare_str,
+    contains,
+    equals,
+    startswith,
+)
 
 
 def make_labels(helper, result):
@@ -67,7 +74,7 @@ def score_by_autocomplete_distance(helper, result):
         if score:
             result.add_score("str_distance", score, ceiling=1.0)
     if not score:
-        _score_by_str_distance(helper, result, scale=0.9)
+        _score_by_ngram_distance(helper, result, scale=0.9)
 
 
 def _score_by_str_distance(helper, result, scale=1.0):
@@ -82,7 +89,19 @@ def score_by_str_distance(helper, result):
     _score_by_str_distance(helper, result)
 
 
-score_by_ngram_distance = score_by_str_distance  # Retrocompat.
+def _score_by_ngram_distance(helper, result, scale=1.0):
+    for label in result.labels:
+        label = ascii(label)
+        score = compare_ngrams(label, helper.query) * scale
+        result.add_score("str_distance", score, ceiling=1.0)
+        if score >= config.MATCH_THRESHOLD:
+            break
+
+
+def score_by_ngram_distance(helper, result):
+    if helper.autocomplete:
+        return
+    _score_by_ngram_distance(helper, result)
 
 
 def score_by_geo_distance(helper, result):

--- a/addok/helpers/text.py
+++ b/addok/helpers/text.py
@@ -2,6 +2,8 @@ import re
 from functools import lru_cache
 from pathlib import Path
 
+import editdistance
+from ngram import NGram
 from unidecode import unidecode
 
 from addok.config import config
@@ -9,7 +11,6 @@ from addok.db import DB
 from addok.helpers import keys, yielder
 from addok.helpers.index import token_frequency
 
-import editdistance
 
 PATTERN = re.compile(r"[\w]+", re.U | re.X)
 
@@ -159,6 +160,16 @@ def ngrams(text, n=3):
     # same ngrams whether at the start, the middle or the end of the string.
     text = " " + text + " "
     return set([text[i : i + n] for i in range(0, len(text) - (n - 1))])
+
+
+def compare_ngrams(left, right, N=2, pad_len=0):
+    left = ascii(left)
+    right = ascii(right)
+    if len(left) == 1 and len(right) == 1:
+        # NGram.compare returns 0.0 for 1 letter comparison, even if letters
+        # are equal.
+        return 1.0 if left == right else 0.0
+    return NGram.compare(left, right, N=N, pad_len=pad_len)
 
 
 def compare_str(left, right):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ falcon==3.1.1
 hashids==1.3.1
 hiredis==2.0.0
 editdistance==0.6.1
+ngram==3.3.2
 progressist==0.1.0
 python-geohash==0.8.5
 redis==4.3.5

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -404,8 +404,15 @@ def test_word_order_priority(factory):
     factory(name="avenue de saint-mandé", city="paris", importance=0.0463)
     results = search("avenue de paris saint-mandé")
     assert results[0].name == "avenue de paris"
-    results = search("avenue de paris saint-mandé france")
-    assert results[0].name == "avenue de paris"
+
+    # Does not work with compare_ngram.
+    # Both document have same score:
+    # Comparing "avenue de paris saint-mandé france"
+    # - with "avenue de saint-mandé paris" => 0.7878787878787878
+    # - with "avenue de paris saint-mandé" => 0.7878787878787878
+    # results = search("avenue de paris saint-mandé france")
+    # assert results[0].name == "avenue de paris"
+
     results = search("avenue de saint-mandé paris")
     assert results[0].name == "avenue de saint-mandé"
 


### PR DESCRIPTION
We want to lower the breaking change for a new stable release.

Some people may have hardcoded some score values returned by Addok in order to distriminate results to keep or not (for example in the CSV mass geocoding)

cc @cquest @jdesboeufs 