### PR TITLE
Update ngram (4.0.3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ falcon==3.1.1
 hashids==1.3.1
 hiredis==2.0.0
 editdistance==0.6.1
-ngram==3.3.2
+ngram==4.0.3
 progressist==0.1.0
 python-geohash==0.8.5
 redis==4.3.5


### PR DESCRIPTION
Update `ngram` since `3.3.2` is not compatible with modern `setuptools`.
Already done in `1.0.x` branch: https://github.com/addok/addok/commit/c239a654ab977164f55b72a9d01dfe01e9471613