### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added `ID_FIELD` to control which field is used as document `_id`
 - `config.SYNONYMS_PATH` is now `config.SYNONYMS_PATHS` and is a list to allow
   multiple files
-- Fixed non unique id accross multiple docker sharing same Redis instance (#[607](https://github.com/etalab/addok/issues/607))
+- Fixed non unique id across multiple docker sharing same Redis instance (#[607](https://github.com/etalab/addok/issues/607))
 - Added more variants for `lat` and `lon` params and better control their values (#[592](https://github.com/etalab/addok/issues/592))
 - Better ordering of candidates in case of autocomplete (#[494](https://github.com/etalab/addok/issues/494))
 - By default, use more common chars when building fuzzy variants

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to around 2000 searches per second.
 Check the [documentation](http://addok.readthedocs.org/en/latest/) and a
 [demo](http://adresse.data.gouv.fr/map) with French data.
 
-For discussions, please use the [discourse Geocommun forum](https://forum.geocommuns.fr/c/adresses/addok-le-geocodeur/17). Discussions are mostly French, but English is very welcome. 
+For discussions, please use the [discourse Geocommun forum](https://forum.geocommuns.fr/c/adresses/addok-le-geocodeur/17). Discussions are mostly French, but English is very welcome.
 
 Powered by Python and Redis.
 

--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -17,10 +17,10 @@ REDIS = {
 BUCKET_MIN = 10
 BUCKET_MAX = 100
 
-# Above this treshold, terms are considered commons.
+# Above this threshold, terms are considered commons.
 COMMON_THRESHOLD = 10000
 
-# Above this treshold, we avoid intersecting sets.
+# Above this threshold, we avoid intersecting sets.
 INTERSECT_LIMIT = 100000
 
 # Min score considered matching the query.
@@ -160,7 +160,7 @@ SLOW_QUERIES = False  # False or time in ms to consider query as slow
 
 INDEX_EDGE_NGRAMS = True
 
-# surrouding letters on a standard keyboard (default french azerty)
+# surrounding letters on a standard keyboard (default french azerty)
 FUZZY_KEY_MAP = {
     "a": "ezqop",
     "z": "aqse",

--- a/docs/api.md
+++ b/docs/api.md
@@ -93,4 +93,4 @@ Parameters:
 - every filter that has been declared in the [config](config.md) is available as
   parameters
 
-Same response format as the `/search/` enpoint.
+Same response format as the `/search/` endpoint.

--- a/docs/config.md
+++ b/docs/config.md
@@ -81,7 +81,7 @@ To use Redis through a Unix socket, use `unix_socket_path` key.
 
 #### LOG_DIR (path)
 Path to the directory Addok will write its log and history files. Can also
-be overriden from the environment variable `ADDOK_LOG_DIR`.
+be overridden from the environment variable `ADDOK_LOG_DIR`.
 
     LOG_DIR = 'path/to/dir'
 
@@ -167,7 +167,7 @@ The licence of the data returned by the API. Can be a simple string, or a dict.
     LICENCE = {'source': 'licence', 'source2': 'licence2'}
 
 #### LOG_QUERIES (boolean)
-Turn this to `True` to log every query received and firt result if any. *Note:
+Turn this to `True` to log every query received and first result if any. *Note:
 only the queries are logged, not any of the other received data.*
 
     LOG_QUERIES = False
@@ -240,7 +240,7 @@ This may impact performances a lot.
     BUCKET_MAX = 100
 
 #### COMMON_THRESHOLD (int)
-Above this treshold, terms are considered commons, and thus with less importance
+Above this threshold, terms are considered commons, and thus with less importance
 in the search algorithm.
 
     COMMON_THRESHOLD = 10000
@@ -277,7 +277,7 @@ The max inherent score of geographical distance to the provided center (if any) 
     GEO_DISTANCE_WEIGHT = 0.1
 
 #### INTERSECT_LIMIT (int)
-Above this treshold, we avoid intersecting sets.
+Above this threshold, we avoid intersecting sets.
 
     INTERSECT_LIMIT = 100000
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -18,7 +18,7 @@ Check each plugin home page to have specific documentation.
   (better typo tolerance).
 - [addok-csv](https://github.com/addok/addok-csv): add a CSV endpoint to your Addok server (for batch
   geocoding of CSV files)
-- [addok-psql](https://github.com/addok/addok-psql): import from PosgreSQL database into Addok.
+- [addok-psql](https://github.com/addok/addok-psql): import from PostgreSQL database into Addok.
 - [addok-trigrams](https://github.com/addok/addok-trigrams): alternative index algorithm based on trigrams.
 - [addok-sqlite-store](https://github.com/addok/addok-sqlite-store): store documents into SQLite.
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -109,7 +109,7 @@ Do a reverse search. Args: lat lon.
 
 #### SEARCH
 Issue a search (default command, can be omitted; arguments between `[]` are
-optionnal):
+optional):
 
     SEARCH rue des Lilas [CENTER lat lon] [LIMIT 10] [AUTOCOMPLETE 0]
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -58,7 +58,7 @@ Check that the installation is successful so far by running this command:
 If you see no error but the list of addok commands, congratulations, you can proceed!
 
 If not, keep courage, try to read the error message, go back through previous steps and
-check that everything has been done successfuly. And if you are lost, [create an issue the addok
+check that everything has been done successfully. And if you are lost, [create an issue the addok
 tracker](https://github.com/addok/addok/issues) to ask for help.
 
 ## Create a local configuration file
@@ -289,5 +289,5 @@ Congratulations!
   You'll be able to check all the configuration keys and be sure they have the
   expected values.
 
-- If your searchs are returning nothing at all or very weird results, it may be that you have
+- If your searches are returning nothing at all or very weird results, it may be that you have
   indexed with a different configuration than the one you are using when searching.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -165,7 +165,7 @@ def test_search_should_not_split_querystring_on_commas(client, factory):
     assert resp.json["query"] == "18, rue des avions"
 
 
-def test_query_string_lenght_should_be_checked(client, config):
+def test_query_string_length_should_be_checked(client, config):
     config.QUERY_MAX_LENGTH = 10
     resp = client.get("/search/", query_string={"q": "this is too long"})
     assert resp.status_code == 413
@@ -191,7 +191,7 @@ def test_geojson_should_have_document_type_as_key(client, factory):
     resp = client.get("/search/", query_string={"q": "rue de foobar"})
     properties = resp.json["features"][0]["properties"]
     assert properties["name"] == "rue de foobar"
-    assert properties["foo"] == "bar"  # Not overrided.
+    assert properties["foo"] == "bar"  # Not overridden.
 
 
 def test_search_should_catch_invalid_lat(client):


### PR DESCRIPTION
Found via `codespell -S .mypy_cache,.git -L
somme,adresse,adresses,fot,mor,mot,yot,matchs`