### PR TITLE
Build against Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,6 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.6"
+          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,7 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==7.3.0
+pytest==7.0.1
 pytest-cov==4.0.0
 pytest-falcon==0.4.2
 fabric==2.1.3


### PR DESCRIPTION
Add Python 3.6 and 3.7 to build matrix on GitHub Actions.
For testing purpose.