### PR TITLE
Update redis ans hiredis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 falcon==3.1.1
 hashids==1.3.1
-hiredis==2.0.0
+hiredis==2.2.2
 editdistance==0.6.2
 ngram==4.0.3
 progressist==0.1.0
 python-geohash==0.8.5
-redis==4.3.6
+redis==4.5.4
 Unidecode==1.3.6


### PR DESCRIPTION
Update redis from 4.3.6 to 4.5.4
Update hiredis from 2.0.0 to 2.2.2

Python 3.6 not supported anymore but no breaking changes.