### PR TITLE
Use LRU cache for preprocess

### DIFF
--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -36,6 +36,9 @@ GEOHASH_PRECISION = 7
 MIN_EDGE_NGRAMS = 3
 MAX_EDGE_NGRAMS = 20
 
+# Maximum entries stored by preprocess LRU cache
+PREPROCESS_CACHE_SIZE = 10000
+
 SYNONYMS_PATHS = []
 
 # Pipeline stream to be used.

--- a/addok/helpers/index.py
+++ b/addok/helpers/index.py
@@ -1,5 +1,6 @@
 import geohash
 import redis
+from functools import lru_cache
 
 from addok.config import config
 from addok.db import DB
@@ -10,13 +11,9 @@ from . import iter_pipe, keys, yielder
 VALUE_SEPARATOR = "|~|"
 
 
+@lru_cache(maxsize=getattr(config, "PREPROCESS_CACHE_SIZE", 10000))
 def preprocess(s):
-    if s not in _CACHE:
-        _CACHE[s] = list(iter_pipe(s, config.PROCESSORS))
-    return _CACHE[s]
-
-
-_CACHE = {}
+    return tuple(iter_pipe(s, config.PROCESSORS))
 
 
 def token_key_frequency(key):


### PR DESCRIPTION
## Summary
- speed up token preprocessing with `functools.lru_cache`
- add `PREPROCESS_CACHE_SIZE` setting

## Testing
- `pytest -q`