### PR TITLE
Optimize token relation computation

### DIFF
--- a/addok/helpers/collectors.py
+++ b/addok/helpers/collectors.py
@@ -159,11 +159,19 @@ def _extract_manytomany_relations(tokens):
 
 def _compute_onetomany_relations(tokens):
     relations = defaultdict(list)
+    # Memoize DB.sismember results by preloading token pairs
+    pair_cache = {
+        token: {
+            t.decode() if isinstance(t, bytes) else t
+            for t in DB.smembers(pair_key(token))
+        }
+        for token in tokens
+    }
     for token in tokens:
         for other in tokens:
             if other == token:
                 continue
-            if token in relations[other] or DB.sismember(pair_key(token), other):
+            if token in relations[other] or other in pair_cache[token]:
                 relations[token].append(other)
     return relations
 

--- a/benchmarks/benchmark_onetomany.py
+++ b/benchmarks/benchmark_onetomany.py
@@ -1,0 +1,40 @@
+import random
+import time
+from addok.helpers.collectors import _compute_onetomany_relations
+from addok.helpers.text import Token
+import addok.helpers.collectors as collectors
+
+class FakeDB:
+    def __init__(self, tokens, ratio=0.1):
+        self.pairs = set()
+        for token in tokens:
+            for other in tokens:
+                if token == other:
+                    continue
+                if random.random() < ratio:
+                    self.pairs.add((str(token), str(other)))
+
+    def smembers(self, key):
+        token = key.split("|", 1)[1]
+        return [other.encode() for t, other in self.pairs if t == token]
+
+# Number of tokens can be adjusted to mimic realistic queries
+TOKEN_COUNT = 50
+ITERATIONS = 100
+
+tokens = [Token(str(i)) for i in range(TOKEN_COUNT)]
+
+fake_db = FakeDB(tokens)
+
+DB_backup = collectors.DB
+try:
+    # Monkey patch DB with fake one
+    import types
+    collectors.DB = types.SimpleNamespace(smembers=fake_db.smembers)
+    start = time.perf_counter()
+    for _ in range(ITERATIONS):
+        _compute_onetomany_relations(tokens)
+    duration = time.perf_counter() - start
+    print(f"{ITERATIONS} runs in {duration:.4f}s ({TOKEN_COUNT} tokens)")
+finally:
+    collectors.DB = DB_backup

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,5 +1,6 @@
 from addok.helpers.collectors import _extract_manytomany_relations
 from addok.helpers.text import Token
+from addok.helpers.collectors import _compute_onetomany_relations
 
 
 def test_extract_manytomany_relations(factory, config):
@@ -10,6 +11,17 @@ def test_extract_manytomany_relations(factory, config):
     tokens = [Token(s) for s in "rue de paris porte 506 fecamp".split()]
     groups = _extract_manytomany_relations(tokens)
     assert groups == [{Token("fecamp"), Token("paris")}]
+
+
+def test_compute_onetomany_relations(factory, config):
+    config.COMMON_THRESHOLD = 2
+    factory(name="rue de Paris", city="Fecamp")
+    factory(name="rue de la porte")
+    factory(name="rue de dieppe", housenumbers={"506": {"lat": 1, "lon": 2}})
+    tokens = [Token(s) for s in "rue de paris porte 506 fecamp".split()]
+    relations = _compute_onetomany_relations(tokens)
+    assert Token("fecamp") in relations[Token("paris")]
+    assert Token("paris") in relations[Token("fecamp")]
 
 
 def test_extract_manytomany_relations_2(factory, config):


### PR DESCRIPTION
## Summary
- memoize relation lookup in `_compute_onetomany_relations`
- add benchmark script for the relation computation
- test the new behaviour explicitly

## Testing
- `pytest -q`
- `python benchmarks/benchmark_onetomany.py`
