### PR TITLE
Avoid filling bucket using only common tokens (fixes #437)

### DIFF
--- a/addok/helpers/collectors.py
+++ b/addok/helpers/collectors.py
@@ -68,6 +68,12 @@ def only_commons(helper):
 def bucket_with_meaningful(helper):
     if not helper.meaningful:
         return
+
+    if (helper.common and helper.bucket_dry and
+        (not helper.meaningful or helper.meaningful[0].frequency > config.COMMON_THRESHOLD)):
+            helper.debug("Still only not found and common tokens.")
+            return
+
     if len(helper.meaningful) == 1 and helper.common and not helper.filters:
         # Avoid running with too less tokens while having commons terms.
         for token in helper.common:


### PR DESCRIPTION
Avoid filling bucket using only common tokens when not found tokens are also present (see #437)

Gives a chance for the fuzzy magic... and avoids very long redis index intersections.