### PR TITLE
feat: add username support and simple TLS to Redis configuration

### DIFF
--- a/addok/config/default.py
+++ b/addok/config/default.py
@@ -4,7 +4,11 @@ from pathlib import Path
 REDIS = {
     "host": os.environ.get("REDIS_HOST") or "localhost",
     "port": os.environ.get("REDIS_PORT") or 6379,
+    "username": os.environ.get("REDIS_USER") or "default",
     "unix_socket_path": os.environ.get("REDIS_SOCKET"),
+    # TLS/SSL configuration (basic CA-only support)
+    "ssl": os.environ.get("REDIS_SSL", "false").lower() == "true",
+    "ssl_ca_certs": os.environ.get("REDIS_SSL_CA_CERTS"),
     "indexes": {
         "db": os.environ.get("REDIS_DB_INDEXES") or 0,
     },

--- a/addok/db.py
+++ b/addok/db.py
@@ -37,9 +37,13 @@ def _extract_redis_config(config_section):
     return {
         "host": config_section.get("host"),
         "port": config_section.get("port"),
+        "username": config_section.get("username"),
         "db": config_section.get("db"),
         "password": config_section.get("password"),
         "unix_socket_path": config_section.get("unix_socket_path"),
+        # TLS/SSL parameters (basic CA-only support)
+        "ssl": config_section.get("ssl"),
+        "ssl_ca_certs": config_section.get("ssl_ca_certs"),
     }
 
 

--- a/addok/ds.py
+++ b/addok/ds.py
@@ -48,10 +48,14 @@ def on_load():
         params.update(config.REDIS.get("documents", {}))
         _DB.connect(
             host=params.get("host"),
+            username=params.get("username") or "default",
             port=params.get("port"),
             db=params.get("db"),
             password=params.get("password"),
             unix_socket_path=params.get("unix_socket_path"),
+            # TLS/SSL parameters (basic CA-only support)
+            ssl=params.get("ssl"),
+            ssl_ca_certs=params.get("ssl_ca_certs"),
         )
 
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,6 +52,7 @@ subdictionnaries, for example:
     REDIS = {
         'host': 'myhost',
         'port': 6379,
+        'username': 'default',
         'indexes': {
             'db': 11,
         },
@@ -64,6 +65,7 @@ If your hosts are different, you can define them like this:
 
     REDIS = {
         'port': 6379,
+        'username': 'default',
         'indexes': {
             'host': 'myhost1',
             'db': 11,
@@ -75,6 +77,33 @@ If your hosts are different, you can define them like this:
     }
 
 And of course, same for the port.
+
+### TLS/SSL Configuration
+
+Addok supports secure Redis connections using TLS/SSL with basic CA certificate support. This is similar to the Redis CLI usage:
+
+```bash
+redis-cli -h 192.0.2.1 -p 6379 --user <redis-user> --askpass --tls --cacert SSL_<redis-cluster-name>.pem
+```
+
+You can configure TLS parameters in the `REDIS` section:
+
+```python
+REDIS = {
+    'host': 'redis.example.com',
+    'port': 6380,
+    'username': 'user',
+    'password': 'secret',
+    # TLS/SSL parameters (basic CA-only support)
+    'ssl': True,                    # Enable SSL/TLS
+    'ssl_ca_certs': '/path/to/ca.pem',  # CA certificate file
+}
+```
+
+**Environment Variables:**
+TLS parameters can also be configured via environment variables:
+- `REDIS_SSL=true` or `false` - Enable TLS
+- `REDIS_SSL_CA_CERTS=/path/to/ca.pem` - CA certificate file path
 
 To use Redis through a Unix socket, use `unix_socket_path` key.
 

--- a/tests/test_db_helpers.py
+++ b/tests/test_db_helpers.py
@@ -7,9 +7,13 @@ def test_extract_redis_config_with_all_params():
     config_section = {
         "host": "redis.example.com",
         "port": 6380,
+        "username": "user",
         "db": 5,
         "password": "secret123",
         "unix_socket_path": "/var/run/redis.sock",
+        # TLS parameters (basic CA-only)
+        "ssl": True,
+        "ssl_ca_certs": "/path/to/ca.pem",
     }
 
     result = _extract_redis_config(config_section)
@@ -17,8 +21,12 @@ def test_extract_redis_config_with_all_params():
     assert result["host"] == "redis.example.com"
     assert result["port"] == 6380
     assert result["db"] == 5
+    assert result["username"] == "user"
     assert result["password"] == "secret123"
     assert result["unix_socket_path"] == "/var/run/redis.sock"
+    # TLS assertions (basic CA-only)
+    assert result["ssl"] == True
+    assert result["ssl_ca_certs"] == "/path/to/ca.pem"
 
 
 def test_extract_redis_config_with_minimal_params():
@@ -34,8 +42,12 @@ def test_extract_redis_config_with_minimal_params():
     assert result["host"] == "localhost"
     assert result["port"] == 6379
     assert result["db"] == 0
+    assert result["username"] == "default"
     assert result["password"] is None
     assert result["unix_socket_path"] is None
+    # TLS parameters should be None when not provided (basic CA-only)
+    assert result["ssl"] is None
+    assert result["ssl_ca_certs"] is None
 
 
 def test_extract_redis_config_handles_missing_keys():
@@ -47,8 +59,12 @@ def test_extract_redis_config_handles_missing_keys():
     assert result["host"] is None
     assert result["port"] is None
     assert result["db"] is None
+    assert result["username"] is None
     assert result["password"] is None
     assert result["unix_socket_path"] is None
+    # TLS parameters should be None when not provided (basic CA-only)
+    assert result["ssl"] is None
+    assert result["ssl_ca_certs"] is None
 
 
 def test_get_redis_params_returns_structured_dict():
@@ -66,7 +82,12 @@ def test_get_redis_params_returns_structured_dict():
     assert isinstance(result["use_redis_documents"], bool)
 
     # Should have standard Redis connection keys
-    for key in ["host", "port", "db", "password", "unix_socket_path"]:
+    # Standard Redis connection keys
+    for key in ["host", "port", "db", "username", "password", "unix_socket_path"]:
+        assert key in result["indexes"]
+        assert key in result["documents"]
+    # TLS/SSL keys (basic CA-only)
+    for key in ["ssl", "ssl_ca_certs"]:
         assert key in result["indexes"]
         assert key in result["documents"]
 
@@ -91,3 +112,22 @@ def test_get_redis_params_detects_redis_document_store(config):
     # Should correctly identify if using Redis for documents
     expected = addok_config.DOCUMENT_STORE == ds.RedisStore
     assert result["use_redis_documents"] == expected
+
+
+def test_extract_redis_config_with_tls_params():
+    """Test extraction of Redis config with TLS parameters (basic CA-only)."""
+    config_section = {
+        "host": "redis.example.com",
+        "port": 6380,
+        "username": "user",
+        "db": 5,
+        # TLS parameters (basic CA-only)
+        "ssl": True,
+        "ssl_ca_certs": "/path/to/ca.pem",
+    }
+
+    result = _extract_redis_config(config_section)
+
+    # Verify TLS parameters are extracted correctly (basic CA-only)
+    assert result["ssl"] == True
+    assert result["ssl_ca_certs"] == "/path/to/ca.pem"


### PR DESCRIPTION
Changes:
- Add username parameter to match redis-py API, allowing to use an username other than 'default'
- Add basic TLS support with CA certificates (ssl + ssl_ca_certs)
- Update config, code, tests, and docs
- Maintain backward compatibility